### PR TITLE
feat(domain): add all domain models, enums, and repository protocols

### DIFF
--- a/AarogyaiOS/Domain/Models/AccessGrant.swift
+++ b/AarogyaiOS/Domain/Models/AccessGrant.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct AccessGrant: Identifiable, Sendable {
+    let id: String
+    var patientId: String
+    var grantedToUserId: String
+    var grantedToUserName: String?
+    var grantedByUserId: String
+    var grantReason: String?
+    var scope: AccessScope
+    var status: AccessGrantStatus
+    var startsAt: Date
+    var expiresAt: Date?
+    var revokedAt: Date?
+    var createdAt: Date
+}
+
+struct AccessScope: Sendable {
+    var allReports: Bool
+    var reportIds: [String]
+}

--- a/AarogyaiOS/Domain/Models/AccessGrantStatus.swift
+++ b/AarogyaiOS/Domain/Models/AccessGrantStatus.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum AccessGrantStatus: String, Codable, Sendable {
+    case active
+    case revoked
+    case expired
+}

--- a/AarogyaiOS/Domain/Models/BloodGroup.swift
+++ b/AarogyaiOS/Domain/Models/BloodGroup.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum BloodGroup: String, Codable, CaseIterable, Sendable {
+    case aPositive = "A+"
+    case aNegative = "A-"
+    case bPositive = "B+"
+    case bNegative = "B-"
+    case abPositive = "AB+"
+    case abNegative = "AB-"
+    case oPositive = "O+"
+    case oNegative = "O-"
+}

--- a/AarogyaiOS/Domain/Models/ConsentPurpose.swift
+++ b/AarogyaiOS/Domain/Models/ConsentPurpose.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum ConsentPurpose: String, Codable, CaseIterable, Sendable {
+    case profileManagement = "ProfileManagement"
+    case medicalRecordsProcessing = "MedicalRecordsProcessing"
+    case medicalDataSharing = "MedicalDataSharing"
+    case emergencyContactManagement = "EmergencyContactManagement"
+
+    var displayName: String {
+        switch self {
+        case .profileManagement: "Profile Management"
+        case .medicalRecordsProcessing: "Medical Records Processing"
+        case .medicalDataSharing: "Medical Data Sharing"
+        case .emergencyContactManagement: "Emergency Contact Management"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .profileManagement:
+            "Allow processing of your profile data"
+        case .medicalRecordsProcessing:
+            "Allow processing of your medical records"
+        case .medicalDataSharing:
+            "Allow sharing records with healthcare providers"
+        case .emergencyContactManagement:
+            "Allow emergency contacts to access records"
+        }
+    }
+
+    var isRequired: Bool {
+        switch self {
+        case .profileManagement, .medicalRecordsProcessing: true
+        case .medicalDataSharing, .emergencyContactManagement: false
+        }
+    }
+}

--- a/AarogyaiOS/Domain/Models/ConsentRecord.swift
+++ b/AarogyaiOS/Domain/Models/ConsentRecord.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ConsentRecord: Identifiable, Sendable {
+    var id: String { purpose.rawValue }
+    var purpose: ConsentPurpose
+    var isGranted: Bool
+    var source: String
+    var occurredAt: Date
+}

--- a/AarogyaiOS/Domain/Models/DeviceToken.swift
+++ b/AarogyaiOS/Domain/Models/DeviceToken.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct DeviceToken: Identifiable, Sendable {
+    let id: String
+    var deviceToken: String
+    var platform: String
+    var deviceName: String
+    var appVersion: String
+    var registeredAt: Date
+    var updatedAt: Date
+}

--- a/AarogyaiOS/Domain/Models/DoctorProfile.swift
+++ b/AarogyaiOS/Domain/Models/DoctorProfile.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct DoctorProfile: Sendable {
+    let id: String
+    var medicalLicenseNumber: String
+    var specialization: String
+    var clinicOrHospitalName: String?
+    var clinicAddress: String?
+}

--- a/AarogyaiOS/Domain/Models/EmergencyContact.swift
+++ b/AarogyaiOS/Domain/Models/EmergencyContact.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct EmergencyContact: Identifiable, Sendable {
+    let id: String
+    var name: String
+    var phone: String
+    var relationship: Relationship
+    var isPrimary: Bool
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/AarogyaiOS/Domain/Models/ExtractionStatus.swift
+++ b/AarogyaiOS/Domain/Models/ExtractionStatus.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum ExtractionStatus: String, Codable, Sendable {
+    case pending
+    case inProgress = "in_progress"
+    case completed
+    case failed
+}

--- a/AarogyaiOS/Domain/Models/Gender.swift
+++ b/AarogyaiOS/Domain/Models/Gender.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum Gender: String, Codable, CaseIterable, Sendable {
+    case male
+    case female
+    case other
+}

--- a/AarogyaiOS/Domain/Models/LabTechnicianProfile.swift
+++ b/AarogyaiOS/Domain/Models/LabTechnicianProfile.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct LabTechnicianProfile: Sendable {
+    let id: String
+    var labName: String
+    var labLicenseNumber: String?
+    var nablAccreditationId: String?
+}

--- a/AarogyaiOS/Domain/Models/NotificationPreferences.swift
+++ b/AarogyaiOS/Domain/Models/NotificationPreferences.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct NotificationPreferences: Sendable {
+    var reportUploaded: ChannelPreferences
+    var accessGranted: ChannelPreferences
+    var emergencyAccess: ChannelPreferences
+}
+
+struct ChannelPreferences: Sendable {
+    var push: Bool
+    var email: Bool
+    var sms: Bool
+}

--- a/AarogyaiOS/Domain/Models/RegistrationStatus.swift
+++ b/AarogyaiOS/Domain/Models/RegistrationStatus.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum RegistrationStatus: String, Codable, Sendable {
+    case registered
+    case pendingApproval = "pending_approval"
+    case approved
+    case rejected
+}

--- a/AarogyaiOS/Domain/Models/Relationship.swift
+++ b/AarogyaiOS/Domain/Models/Relationship.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum Relationship: String, Codable, CaseIterable, Sendable {
+    case spouse
+    case parent
+    case sibling
+    case child
+    case friend
+    case other
+}

--- a/AarogyaiOS/Domain/Models/Report.swift
+++ b/AarogyaiOS/Domain/Models/Report.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct Report: Identifiable, Sendable {
+    let id: String
+    let reportNumber: String
+    var title: String
+    var reportType: ReportType
+    var status: ReportStatus
+    var patientId: String
+    var doctorId: String?
+    var doctorName: String?
+    var labName: String?
+    var collectedAt: Date?
+    var reportedAt: Date?
+    var uploadedAt: Date
+    var notes: String?
+    var fileStorageKey: String?
+    var fileType: String?
+    var fileSizeBytes: Int?
+    var checksumSha256: String?
+    var parameters: [ReportParameter]
+    var extraction: ReportExtraction?
+    var highlightParameter: String?
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/AarogyaiOS/Domain/Models/ReportExtraction.swift
+++ b/AarogyaiOS/Domain/Models/ReportExtraction.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ReportExtraction: Sendable {
+    var status: ExtractionStatus
+    var extractionMethod: String?
+    var structuringModel: String?
+    var extractedParameterCount: Int
+    var overallConfidence: Double?
+    var pageCount: Int?
+    var extractedAt: Date?
+    var errorMessage: String?
+    var attemptCount: Int
+}

--- a/AarogyaiOS/Domain/Models/ReportParameter.swift
+++ b/AarogyaiOS/Domain/Models/ReportParameter.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct ReportParameter: Identifiable, Sendable {
+    let id: String
+    var code: String
+    var name: String
+    var numericValue: Double?
+    var textValue: String?
+    var unit: String?
+    var referenceRange: String?
+    var isAbnormal: Bool
+}

--- a/AarogyaiOS/Domain/Models/ReportStatus.swift
+++ b/AarogyaiOS/Domain/Models/ReportStatus.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum ReportStatus: String, Codable, Sendable {
+    case draft
+    case uploaded
+    case processing
+    case clean
+    case infected
+    case validated
+    case published
+    case archived
+    case extracting
+    case extracted
+    case extractionFailed = "extraction_failed"
+}

--- a/AarogyaiOS/Domain/Models/ReportType.swift
+++ b/AarogyaiOS/Domain/Models/ReportType.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum ReportType: String, Codable, CaseIterable, Sendable {
+    case bloodTest = "blood_test"
+    case urineTest = "urine_test"
+    case radiology
+    case cardiology
+    case other
+}

--- a/AarogyaiOS/Domain/Models/User.swift
+++ b/AarogyaiOS/Domain/Models/User.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct User: Identifiable, Sendable {
+    let id: String
+    var firstName: String
+    var lastName: String
+    var email: String
+    var phone: String
+    var address: String?
+    var bloodGroup: BloodGroup?
+    var dateOfBirth: Date?
+    var gender: Gender?
+    var role: UserRole
+    var registrationStatus: RegistrationStatus
+    var isAadhaarVerified: Bool
+    var aadhaarRefToken: String?
+    var doctorProfile: DoctorProfile?
+    var labTechProfile: LabTechnicianProfile?
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/AarogyaiOS/Domain/Models/UserRole.swift
+++ b/AarogyaiOS/Domain/Models/UserRole.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum UserRole: String, Codable, CaseIterable, Sendable {
+    case patient
+    case doctor
+    case labTechnician = "lab_technician"
+    case admin
+}

--- a/AarogyaiOS/Domain/Repositories/AccessGrantRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/AccessGrantRepository.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+protocol AccessGrantRepository: Sendable {
+    func createGrant(request: CreateAccessGrantInput) async throws -> AccessGrant
+    func getGrants() async throws -> [AccessGrant]
+    func getReceivedGrants() async throws -> [AccessGrant]
+    func revokeGrant(id: String) async throws
+}
+
+struct CreateAccessGrantInput: Sendable {
+    let grantedToUserId: String
+    let scope: AccessScope
+    let grantReason: String?
+    let expiresAt: Date?
+}

--- a/AarogyaiOS/Domain/Repositories/AuthRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/AuthRepository.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+protocol AuthRepository: Sendable {
+    func socialAuthorize(provider: String) async throws -> URL
+    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens
+    func requestOTP(phone: String) async throws
+    func verifyOTP(phone: String, otp: String) async throws -> AuthTokens
+    func refreshToken(refreshToken: String) async throws -> AuthTokens
+    func revokeToken(refreshToken: String) async throws
+    func getCurrentUser() async throws -> User
+}
+
+struct AuthTokens: Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let idToken: String
+    let expiresIn: Int
+}

--- a/AarogyaiOS/Domain/Repositories/ConsentRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/ConsentRepository.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol ConsentRepository: Sendable {
+    func upsertConsent(purpose: ConsentPurpose, isGranted: Bool) async throws -> ConsentRecord
+}

--- a/AarogyaiOS/Domain/Repositories/EmergencyContactRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/EmergencyContactRepository.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+protocol EmergencyContactRepository: Sendable {
+    func getContacts() async throws -> [EmergencyContact]
+    func createContact(request: EmergencyContactInput) async throws -> EmergencyContact
+    func updateContact(id: String, request: EmergencyContactInput) async throws -> EmergencyContact
+    func deleteContact(id: String) async throws
+    func requestEmergencyAccess(contactPhone: String) async throws
+}
+
+struct EmergencyContactInput: Sendable {
+    let name: String
+    let phone: String
+    let relationship: Relationship
+    let isPrimary: Bool
+}

--- a/AarogyaiOS/Domain/Repositories/NotificationRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/NotificationRepository.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol NotificationRepository: Sendable {
+    func getPreferences() async throws -> NotificationPreferences
+    func updatePreferences(_ preferences: NotificationPreferences) async throws -> NotificationPreferences
+    func registerDevice(token: String) async throws -> DeviceToken
+    func unregisterDevice(token: String) async throws
+}

--- a/AarogyaiOS/Domain/Repositories/ReportRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/ReportRepository.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+protocol ReportRepository: Sendable {
+    func getReports(page: Int, pageSize: Int, type: ReportType?, status: ReportStatus?, search: String?) async throws -> PaginatedResult<Report>
+    func getReport(id: String) async throws -> Report
+    func createReport(request: CreateReportInput) async throws -> Report
+    func deleteReport(id: String) async throws
+    func getUploadURL(fileName: String, contentType: String) async throws -> PresignedUpload
+    func getDownloadURL(reportId: String) async throws -> URL
+    func getExtractionStatus(reportId: String) async throws -> ReportExtraction
+    func triggerExtraction(reportId: String) async throws
+}
+
+struct PaginatedResult<T: Sendable>: Sendable {
+    let items: [T]
+    let page: Int
+    let pageSize: Int
+    let totalCount: Int
+
+    var totalPages: Int {
+        guard pageSize > 0 else { return 0 }
+        return (totalCount + pageSize - 1) / pageSize
+    }
+
+    var hasMore: Bool {
+        page < totalPages
+    }
+}
+
+struct CreateReportInput: Sendable {
+    let fileStorageKey: String
+    let reportType: ReportType
+    let title: String?
+    let reportDate: Date?
+    let doctorName: String?
+    let labName: String?
+    let notes: String?
+}
+
+struct PresignedUpload: Sendable {
+    let uploadURL: URL
+    let fileStorageKey: String
+}

--- a/AarogyaiOS/Domain/Repositories/UserRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/UserRepository.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol UserRepository: Sendable {
+    func getProfile() async throws -> User
+    func updateProfile(_ user: User) async throws -> User
+    func register(request: RegistrationRequest) async throws -> User
+    func getRegistrationStatus() async throws -> RegistrationStatus
+    func verifyAadhaar(token: String) async throws -> User
+    func exportData() async throws
+    func requestDeletion() async throws
+}
+
+struct RegistrationRequest: Sendable {
+    let firstName: String
+    let lastName: String
+    let email: String
+    let phone: String
+    let dateOfBirth: Date?
+    let gender: Gender?
+    let bloodGroup: BloodGroup?
+    let address: String?
+    let role: UserRole
+    let doctorProfile: DoctorProfileInput?
+    let labTechProfile: LabTechProfileInput?
+    let consents: [ConsentInput]
+}
+
+struct DoctorProfileInput: Sendable {
+    let medicalLicenseNumber: String
+    let specialization: String
+    let clinicOrHospitalName: String?
+    let clinicAddress: String?
+}
+
+struct LabTechProfileInput: Sendable {
+    let labName: String
+    let labLicenseNumber: String?
+    let nablAccreditationId: String?
+}
+
+struct ConsentInput: Sendable {
+    let purpose: ConsentPurpose
+    let isGranted: Bool
+}


### PR DESCRIPTION
## Summary
- 10 domain enums matching backend snake_case raw values (all `Codable, Sendable`)
- 11 domain model structs (all `Sendable`, no framework imports)
- 7 repository protocols defining the contract between domain and data layers
- Input types for mutations: `RegistrationRequest`, `CreateReportInput`, `CreateAccessGrantInput`, `EmergencyContactInput`
- Generic `PaginatedResult<T>` for paginated endpoints

Closes #5, Closes #6, Closes #7, Closes #8, Closes #9

## Test plan
- [x] Project builds successfully (`xcodebuild build`)
- [x] Unit tests pass (`xcodebuild test`)
- [x] All types have no framework imports (pure domain layer)
- [x] All types conform to `Sendable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)