### PR TITLE
feat: add use cases, utilities, PKCE generator, and network monitor

### DIFF
--- a/AarogyaiOS/Domain/Repositories/TokenStoring.swift
+++ b/AarogyaiOS/Domain/Repositories/TokenStoring.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol TokenStoring: Sendable {
+    func store(_ tokens: AuthTokens) async throws
+    func accessToken() async throws -> String
+    func refreshToken() async throws -> String
+    func idToken() async throws -> String
+    func clearAll() async throws
+}

--- a/AarogyaiOS/Domain/UseCases/AccessGrants/CreateAccessGrantUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/AccessGrants/CreateAccessGrantUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct CreateAccessGrantUseCase: Sendable {
+    private let accessGrantRepository: any AccessGrantRepository
+
+    init(accessGrantRepository: any AccessGrantRepository) {
+        self.accessGrantRepository = accessGrantRepository
+    }
+
+    func execute(request: CreateAccessGrantInput) async throws -> AccessGrant {
+        try await accessGrantRepository.createGrant(request: request)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/AccessGrants/FetchAccessGrantsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/AccessGrants/FetchAccessGrantsUseCase.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct FetchAccessGrantsUseCase: Sendable {
+    private let accessGrantRepository: any AccessGrantRepository
+
+    init(accessGrantRepository: any AccessGrantRepository) {
+        self.accessGrantRepository = accessGrantRepository
+    }
+
+    func executeGiven() async throws -> [AccessGrant] {
+        try await accessGrantRepository.getGrants()
+    }
+
+    func executeReceived() async throws -> [AccessGrant] {
+        try await accessGrantRepository.getReceivedGrants()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/AccessGrants/RevokeAccessGrantUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/AccessGrants/RevokeAccessGrantUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RevokeAccessGrantUseCase: Sendable {
+    private let accessGrantRepository: any AccessGrantRepository
+
+    init(accessGrantRepository: any AccessGrantRepository) {
+        self.accessGrantRepository = accessGrantRepository
+    }
+
+    func execute(grantId: String) async throws {
+        try await accessGrantRepository.revokeGrant(id: grantId)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/CheckRegistrationStatusUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/CheckRegistrationStatusUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct CheckRegistrationStatusUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute() async throws -> RegistrationStatus {
+        try await userRepository.getRegistrationStatus()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/ExportDataUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/ExportDataUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ExportDataUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute() async throws {
+        try await userRepository.exportData()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/GetCurrentUserUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/GetCurrentUserUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct GetCurrentUserUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute() async throws -> User {
+        try await userRepository.getProfile()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct LoginUseCase: Sendable {
+    private let authRepository: any AuthRepository
+    private let tokenStore: any TokenStoring
+
+    init(authRepository: any AuthRepository, tokenStore: any TokenStoring) {
+        self.authRepository = authRepository
+        self.tokenStore = tokenStore
+    }
+
+    func executeSocial(provider: String, code: String, codeVerifier: String) async throws -> User {
+        let tokens = try await authRepository.socialToken(code: code, codeVerifier: codeVerifier)
+        try await tokenStore.store(tokens)
+        return try await authRepository.getCurrentUser()
+    }
+
+    func executeOTP(phone: String, otp: String) async throws -> User {
+        let tokens = try await authRepository.verifyOTP(phone: phone, otp: otp)
+        try await tokenStore.store(tokens)
+        return try await authRepository.getCurrentUser()
+    }
+
+    func requestOTP(phone: String) async throws {
+        try await authRepository.requestOTP(phone: phone)
+    }
+
+    func getAuthorizeURL(provider: String) async throws -> URL {
+        try await authRepository.socialAuthorize(provider: provider)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/LogoutUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/LogoutUseCase.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct LogoutUseCase: Sendable {
+    private let authRepository: any AuthRepository
+    private let tokenStore: any TokenStoring
+
+    init(authRepository: any AuthRepository, tokenStore: any TokenStoring) {
+        self.authRepository = authRepository
+        self.tokenStore = tokenStore
+    }
+
+    func execute() async throws {
+        if let refreshToken = try? await tokenStore.refreshToken() {
+            try? await authRepository.revokeToken(refreshToken: refreshToken)
+        }
+        try await tokenStore.clearAll()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/RefreshTokenUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/RefreshTokenUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct RefreshTokenUseCase: Sendable {
+    private let authRepository: any AuthRepository
+    private let tokenStore: any TokenStoring
+
+    init(authRepository: any AuthRepository, tokenStore: any TokenStoring) {
+        self.authRepository = authRepository
+        self.tokenStore = tokenStore
+    }
+
+    func execute() async throws -> AuthTokens {
+        guard let refreshToken = try? await tokenStore.refreshToken() else {
+            throw AuthError.noRefreshToken
+        }
+        let tokens = try await authRepository.refreshToken(refreshToken: refreshToken)
+        try await tokenStore.store(tokens)
+        return tokens
+    }
+}
+
+enum AuthError: Error, Sendable {
+    case noRefreshToken
+    case sessionExpired
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/RegisterUserUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/RegisterUserUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RegisterUserUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute(request: RegistrationRequest) async throws -> User {
+        try await userRepository.register(request: request)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/RequestAccountDeletionUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/RequestAccountDeletionUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RequestAccountDeletionUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute() async throws {
+        try await userRepository.requestDeletion()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/UpdateProfileUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/UpdateProfileUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct UpdateProfileUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute(user: User) async throws -> User {
+        try await userRepository.updateProfile(user)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Auth/VerifyAadhaarUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/VerifyAadhaarUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct VerifyAadhaarUseCase: Sendable {
+    private let userRepository: any UserRepository
+
+    init(userRepository: any UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func execute(token: String) async throws -> User {
+        try await userRepository.verifyAadhaar(token: token)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Consents/ManageConsentsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Consents/ManageConsentsUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ManageConsentsUseCase: Sendable {
+    private let consentRepository: any ConsentRepository
+
+    init(consentRepository: any ConsentRepository) {
+        self.consentRepository = consentRepository
+    }
+
+    func upsert(purpose: ConsentPurpose, isGranted: Bool) async throws -> ConsentRecord {
+        try await consentRepository.upsertConsent(purpose: purpose, isGranted: isGranted)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/EmergencyContacts/FetchEmergencyContactsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/EmergencyContacts/FetchEmergencyContactsUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct FetchEmergencyContactsUseCase: Sendable {
+    private let emergencyContactRepository: any EmergencyContactRepository
+
+    init(emergencyContactRepository: any EmergencyContactRepository) {
+        self.emergencyContactRepository = emergencyContactRepository
+    }
+
+    func execute() async throws -> [EmergencyContact] {
+        try await emergencyContactRepository.getContacts()
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/EmergencyContacts/ManageEmergencyContactUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/EmergencyContacts/ManageEmergencyContactUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct ManageEmergencyContactUseCase: Sendable {
+    private let emergencyContactRepository: any EmergencyContactRepository
+
+    init(emergencyContactRepository: any EmergencyContactRepository) {
+        self.emergencyContactRepository = emergencyContactRepository
+    }
+
+    func create(request: EmergencyContactInput) async throws -> EmergencyContact {
+        try await emergencyContactRepository.createContact(request: request)
+    }
+
+    func update(id: String, request: EmergencyContactInput) async throws -> EmergencyContact {
+        try await emergencyContactRepository.updateContact(id: id, request: request)
+    }
+
+    func delete(id: String) async throws {
+        try await emergencyContactRepository.deleteContact(id: id)
+    }
+
+    func requestEmergencyAccess(contactPhone: String) async throws {
+        try await emergencyContactRepository.requestEmergencyAccess(contactPhone: contactPhone)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Notifications/ManageNotificationsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Notifications/ManageNotificationsUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct ManageNotificationsUseCase: Sendable {
+    private let notificationRepository: any NotificationRepository
+
+    init(notificationRepository: any NotificationRepository) {
+        self.notificationRepository = notificationRepository
+    }
+
+    func getPreferences() async throws -> NotificationPreferences {
+        try await notificationRepository.getPreferences()
+    }
+
+    func updatePreferences(_ preferences: NotificationPreferences) async throws -> NotificationPreferences {
+        try await notificationRepository.updatePreferences(preferences)
+    }
+
+    func registerDevice(token: String) async throws -> DeviceToken {
+        try await notificationRepository.registerDevice(token: token)
+    }
+
+    func unregisterDevice(token: String) async throws {
+        try await notificationRepository.unregisterDevice(token: token)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Reports/DeleteReportUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/DeleteReportUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct DeleteReportUseCase: Sendable {
+    private let reportRepository: any ReportRepository
+
+    init(reportRepository: any ReportRepository) {
+        self.reportRepository = reportRepository
+    }
+
+    func execute(reportId: String) async throws {
+        try await reportRepository.deleteReport(id: reportId)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Reports/DownloadReportUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/DownloadReportUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct DownloadReportUseCase: Sendable {
+    private let reportRepository: any ReportRepository
+
+    init(reportRepository: any ReportRepository) {
+        self.reportRepository = reportRepository
+    }
+
+    func execute(reportId: String) async throws -> URL {
+        try await reportRepository.getDownloadURL(reportId: reportId)
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Reports/FetchReportsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/FetchReportsUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct FetchReportsUseCase: Sendable {
+    private let reportRepository: any ReportRepository
+
+    init(reportRepository: any ReportRepository) {
+        self.reportRepository = reportRepository
+    }
+
+    func execute(
+        page: Int = 1,
+        pageSize: Int = 20,
+        type: ReportType? = nil,
+        status: ReportStatus? = nil,
+        search: String? = nil
+    ) async throws -> PaginatedResult<Report> {
+        try await reportRepository.getReports(
+            page: page,
+            pageSize: pageSize,
+            type: type,
+            status: status,
+            search: search
+        )
+    }
+}

--- a/AarogyaiOS/Domain/UseCases/Reports/UploadReportUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/UploadReportUseCase.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct UploadReportUseCase: Sendable {
+    private let reportRepository: any ReportRepository
+    private let uploadService: any FileUploading
+
+    init(reportRepository: any ReportRepository, uploadService: any FileUploading) {
+        self.reportRepository = reportRepository
+        self.uploadService = uploadService
+    }
+
+    func execute(
+        input: UploadReportInput,
+        onProgress: @Sendable @escaping (Double) -> Void
+    ) async throws -> Report {
+        let presigned = try await reportRepository.getUploadURL(
+            fileName: input.fileName,
+            contentType: input.contentType
+        )
+
+        try await uploadService.upload(
+            data: input.fileData,
+            to: presigned.uploadURL,
+            contentType: input.contentType,
+            onProgress: onProgress
+        )
+
+        return try await reportRepository.createReport(
+            request: CreateReportInput(
+                fileStorageKey: presigned.fileStorageKey,
+                reportType: input.reportType,
+                title: input.title,
+                reportDate: input.reportDate,
+                doctorName: input.doctorName,
+                labName: input.labName,
+                notes: input.notes
+            )
+        )
+    }
+}
+
+struct UploadReportInput: Sendable {
+    let fileData: Data
+    let fileName: String
+    let contentType: String
+    let reportType: ReportType
+    let title: String?
+    let reportDate: Date?
+    let doctorName: String?
+    let labName: String?
+    let notes: String?
+}
+
+protocol FileUploading: Sendable {
+    func upload(data: Data, to url: URL, contentType: String, onProgress: @Sendable @escaping (Double) -> Void) async throws
+}

--- a/AarogyaiOS/Infrastructure/NetworkMonitor.swift
+++ b/AarogyaiOS/Infrastructure/NetworkMonitor.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Network
+import Observation
+
+@Observable
+final class NetworkMonitor: @unchecked Sendable {
+    var isConnected: Bool = true
+    var connectionType: ConnectionType = .unknown
+
+    enum ConnectionType: Sendable {
+        case wifi
+        case cellular
+        case wiredEthernet
+        case unknown
+    }
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.kinvee.aarogya.networkmonitor")
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                self?.isConnected = path.status == .satisfied
+                self?.connectionType = self?.connectionType(from: path) ?? .unknown
+            }
+        }
+    }
+
+    func start() {
+        monitor.start(queue: queue)
+    }
+
+    func stop() {
+        monitor.cancel()
+    }
+
+    private func connectionType(from path: NWPath) -> ConnectionType {
+        if path.usesInterfaceType(.wifi) { return .wifi }
+        if path.usesInterfaceType(.cellular) { return .cellular }
+        if path.usesInterfaceType(.wiredEthernet) { return .wiredEthernet }
+        return .unknown
+    }
+}

--- a/AarogyaiOS/Infrastructure/PKCE/PKCEGenerator.swift
+++ b/AarogyaiOS/Infrastructure/PKCE/PKCEGenerator.swift
@@ -1,0 +1,36 @@
+import Foundation
+import CryptoKit
+
+enum PKCEGenerator {
+    static func generateCodeVerifier(length: Int = 64) -> String {
+        let allowedCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        var verifier = ""
+        for _ in 0..<length {
+            let randomIndex = Int.random(in: 0..<allowedCharacters.count)
+            let character = allowedCharacters[allowedCharacters.index(allowedCharacters.startIndex, offsetBy: randomIndex)]
+            verifier.append(character)
+        }
+        return verifier
+    }
+
+    static func generateCodeChallenge(from verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hash = SHA256.hash(data: data)
+        return Data(hash)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func generateState(length: Int = 32) -> String {
+        let allowedCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        var state = ""
+        for _ in 0..<length {
+            let randomIndex = Int.random(in: 0..<allowedCharacters.count)
+            let character = allowedCharacters[allowedCharacters.index(allowedCharacters.startIndex, offsetBy: randomIndex)]
+            state.append(character)
+        }
+        return state
+    }
+}

--- a/AarogyaiOS/Utilities/Constants.swift
+++ b/AarogyaiOS/Utilities/Constants.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum Constants {
+    enum API {
+        static var baseURL: URL {
+            guard let urlString = Bundle.main.infoDictionary?["API_BASE_URL"] as? String,
+                  let url = URL(string: urlString) else {
+                fatalError("API_BASE_URL not configured in Info.plist")
+            }
+            return url
+        }
+    }
+
+    enum Cognito {
+        static var region: String {
+            guard let region = Bundle.main.infoDictionary?["COGNITO_REGION"] as? String else {
+                fatalError("COGNITO_REGION not configured in Info.plist")
+            }
+            return region
+        }
+    }
+
+    enum Keychain {
+        static let serviceName = "com.kinvee.aarogya.tokens"
+        static let accessTokenKey = "access_token"
+        static let refreshTokenKey = "refresh_token"
+        static let idTokenKey = "id_token"
+    }
+
+    enum Cache {
+        static let reportsListTTL: TimeInterval = 120       // 2 minutes
+        static let reportDetailTTL: TimeInterval = 300      // 5 minutes
+        static let userProfileTTL: TimeInterval = 600       // 10 minutes
+        static let accessGrantsTTL: TimeInterval = 60       // 1 minute
+        static let emergencyContactsTTL: TimeInterval = 300 // 5 minutes
+        static let consentsTTL: TimeInterval = 30           // 30 seconds
+    }
+
+    enum Upload {
+        static let maxFileSizeBytes = 50 * 1024 * 1024 // 50 MB
+    }
+
+    enum EmergencyContacts {
+        static let maxCount = 4
+    }
+
+    enum Pagination {
+        static let defaultPageSize = 20
+    }
+}

--- a/AarogyaiOS/Utilities/Extensions/Date+Formatting.swift
+++ b/AarogyaiOS/Utilities/Extensions/Date+Formatting.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension Date {
+    private static nonisolated(unsafe) let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static nonisolated(unsafe) let displayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    private static nonisolated(unsafe) let shortDisplayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd MMM yyyy"
+        return formatter
+    }()
+
+    init?(iso8601 string: String) {
+        guard let date = Date.iso8601Formatter.date(from: string) else {
+            return nil
+        }
+        self = date
+    }
+
+    var iso8601String: String {
+        Date.iso8601Formatter.string(from: self)
+    }
+
+    var displayString: String {
+        Date.displayFormatter.string(from: self)
+    }
+
+    var shortDisplayString: String {
+        Date.shortDisplayFormatter.string(from: self)
+    }
+
+    var relativeString: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: .now)
+    }
+}

--- a/AarogyaiOS/Utilities/Extensions/String+Validation.swift
+++ b/AarogyaiOS/Utilities/Extensions/String+Validation.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension String {
+    var isValidEmail: Bool {
+        let pattern = #"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return range(of: pattern, options: .regularExpression) != nil
+    }
+
+    var isValidPhone: Bool {
+        let pattern = #"^\+[1-9]\d{6,14}$"#
+        return range(of: pattern, options: .regularExpression) != nil
+    }
+
+    var isValidIndianPhone: Bool {
+        let pattern = #"^\+91[6-9]\d{9}$"#
+        return range(of: pattern, options: .regularExpression) != nil
+    }
+
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/AarogyaiOS/Utilities/Logger.swift
+++ b/AarogyaiOS/Utilities/Logger.swift
@@ -1,0 +1,12 @@
+import OSLog
+
+extension Logger {
+    private static let subsystem = "com.kinvee.aarogya"
+
+    static let network = Logger(subsystem: subsystem, category: "network")
+    static let auth = Logger(subsystem: subsystem, category: "auth")
+    static let data = Logger(subsystem: subsystem, category: "data")
+    static let ui = Logger(subsystem: subsystem, category: "ui")
+    static let upload = Logger(subsystem: subsystem, category: "upload")
+    static let cache = Logger(subsystem: subsystem, category: "cache")
+}


### PR DESCRIPTION
## Summary
- 18 domain use cases across all features (auth, reports, access grants, emergency, consents, notifications)
- `TokenStoring` protocol defining the domain boundary for keychain access
- `PKCEGenerator` using CryptoKit SHA256 for OAuth code challenges
- `NetworkMonitor` wrapping NWPathMonitor with `@Observable`
- `Logger` extension with OSLog categories (no PII logging)
- `Constants` with API URLs, cache TTLs, keychain keys, pagination defaults
- `Date+Formatting` and `String+Validation` utility extensions

Closes #10, Closes #11, Closes #12, Closes #13, Closes #22, Closes #24, Closes #25, Closes #27

## Test plan
- [x] Project builds with zero errors
- [x] Unit tests pass
- [x] SwiftLint passes (fixed parameter count violation)
- [x] All types are Sendable-compatible under strict concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)