### PR TITLE
feat(data): add networking layer, keychain, and auth/user DTOs

### DIFF
--- a/AarogyaiOS/Data/Network/APIClient.swift
+++ b/AarogyaiOS/Data/Network/APIClient.swift
@@ -1,0 +1,138 @@
+import Foundation
+import OSLog
+
+final class APIClient: Sendable {
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+    private let interceptor: AuthInterceptor?
+
+    init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        interceptor: AuthInterceptor? = nil
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.interceptor = interceptor
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+    }
+
+    func request<T: Decodable>(
+        _ endpoint: APIEndpoint,
+        body: (some Encodable)? = Optional<EmptyBody>.none
+    ) async throws -> T {
+        let request = try await buildRequest(endpoint, body: body)
+        let (data, response) = try await execute(request)
+        try validateResponse(response, data: data)
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            Logger.network.error("Decoding error for \(endpoint.path): \(error)")
+            throw APIError.decodingError(underlying: error)
+        }
+    }
+
+    func requestNoContent(
+        _ endpoint: APIEndpoint,
+        body: (some Encodable)? = Optional<EmptyBody>.none
+    ) async throws {
+        let request = try await buildRequest(endpoint, body: body)
+        let (data, response) = try await execute(request)
+        try validateResponse(response, data: data)
+    }
+
+    // MARK: - Private
+
+    private func buildRequest(
+        _ endpoint: APIEndpoint,
+        body: (some Encodable)?
+    ) async throws -> URLRequest {
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent(endpoint.path),
+            resolvingAgainstBaseURL: true
+        )!
+        components.queryItems = endpoint.queryItems
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("iOS", forHTTPHeaderField: "X-Platform")
+
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            request.setValue(version, forHTTPHeaderField: "X-App-Version")
+        }
+
+        if let body {
+            request.httpBody = try encoder.encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        if endpoint.requiresAuth, let interceptor {
+            request = try await interceptor.intercept(request)
+        }
+
+        return request
+    }
+
+    private func execute(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            Logger.network.error("Network error: \(error)")
+            throw APIError.networkError(underlying: error)
+        }
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.networkError(underlying: URLError(.badServerResponse))
+        }
+        Logger.network.debug("\(request.httpMethod ?? "?") \(request.url?.path ?? "?") → \(httpResponse.statusCode)")
+        return (data, httpResponse)
+    }
+
+    private func validateResponse(_ response: HTTPURLResponse, data: Data) throws {
+        switch response.statusCode {
+        case 200...299:
+            return
+        case 401:
+            throw APIError.unauthorized
+        case 403:
+            let errorResponse = try? decoder.decode(ErrorResponse.self, from: data)
+            switch errorResponse?.code {
+            case "registration_required": throw APIError.registrationRequired
+            case "registration_pending": throw APIError.registrationPending
+            case "registration_rejected": throw APIError.registrationRejected
+            default:
+                if let code = errorResponse?.code, code.starts(with: "consent_required") {
+                    throw APIError.consentRequired(purpose: code)
+                }
+                throw APIError.forbidden(code: errorResponse?.code)
+            }
+        case 404:
+            throw APIError.notFound
+        case 400:
+            let errorResponse = try? decoder.decode(ErrorResponse.self, from: data)
+            throw APIError.validationError(fields: errorResponse?.errors ?? [])
+        case 429:
+            let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
+                .flatMap(TimeInterval.init)
+            throw APIError.rateLimited(retryAfter: retryAfter)
+        case 500...599:
+            throw APIError.serverError(status: response.statusCode)
+        default:
+            throw APIError.unknown(status: response.statusCode)
+        }
+    }
+}
+
+struct EmptyBody: Encodable {}

--- a/AarogyaiOS/Data/Network/APIEndpoint.swift
+++ b/AarogyaiOS/Data/Network/APIEndpoint.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+enum APIEndpoint: Sendable {
+    // Auth
+    case socialAuthorize
+    case socialToken
+    case otpRequest
+    case otpVerify
+    case tokenRefresh
+    case tokenRevoke
+    case authMe
+
+    // Users
+    case userProfile
+    case updateProfile
+    case registerUser
+    case registrationStatus
+    case verifyAadhaar
+    case exportData
+    case requestDeletion
+
+    // Reports
+    case reportsList(page: Int, pageSize: Int, type: String?, status: String?, search: String?)
+    case reportDetail(id: String)
+    case createReport
+    case deleteReport(id: String)
+    case uploadUrl
+    case downloadUrl
+    case extractionStatus(id: String)
+    case triggerExtraction(id: String)
+
+    // Access Grants
+    case accessGrants
+    case accessGrantsReceived
+    case createAccessGrant
+    case revokeAccessGrant(id: String)
+
+    // Emergency Contacts
+    case emergencyContacts
+    case createEmergencyContact
+    case updateEmergencyContact(id: String)
+    case deleteEmergencyContact(id: String)
+
+    // Emergency Access
+    case requestEmergencyAccess
+
+    // Consents
+    case upsertConsent(purpose: String)
+
+    // Notifications
+    case notificationPreferences
+    case updateNotificationPreferences
+    case registerDevice
+    case unregisterDevice(token: String)
+
+    var method: HTTPMethod {
+        switch self {
+        case .socialAuthorize, .socialToken, .otpRequest, .otpVerify,
+             .tokenRefresh, .tokenRevoke, .registerUser, .verifyAadhaar,
+             .exportData, .requestDeletion, .createReport, .uploadUrl,
+             .downloadUrl, .triggerExtraction, .createAccessGrant,
+             .createEmergencyContact, .requestEmergencyAccess,
+             .registerDevice:
+            .post
+        case .updateProfile, .updateNotificationPreferences,
+             .updateEmergencyContact, .upsertConsent:
+            .put
+        case .deleteReport, .revokeAccessGrant, .deleteEmergencyContact,
+             .unregisterDevice:
+            .delete
+        default:
+            .get
+        }
+    }
+
+    var path: String {
+        switch self {
+        // Auth
+        case .socialAuthorize: "/api/auth/social/authorize"
+        case .socialToken: "/api/auth/social/token"
+        case .otpRequest: "/api/auth/otp/request"
+        case .otpVerify: "/api/auth/otp/verify"
+        case .tokenRefresh: "/api/auth/token/refresh"
+        case .tokenRevoke: "/api/auth/token/revoke"
+        case .authMe: "/api/auth/me"
+
+        // Users
+        case .userProfile, .updateProfile: "/api/v1/users/me"
+        case .registerUser: "/api/v1/users/register"
+        case .registrationStatus: "/api/v1/users/registration-status"
+        case .verifyAadhaar: "/api/v1/users/aadhaar/verify"
+        case .exportData: "/api/v1/users/export"
+        case .requestDeletion: "/api/v1/users/deletion-request"
+
+        // Reports
+        case .reportsList: "/api/v1/reports"
+        case .reportDetail(let id), .deleteReport(let id): "/api/v1/reports/\(id)"
+        case .createReport: "/api/v1/reports"
+        case .uploadUrl: "/api/v1/reports/upload-url"
+        case .downloadUrl: "/api/v1/reports/download-url"
+        case .extractionStatus(let id): "/api/v1/reports/\(id)/extraction-status"
+        case .triggerExtraction(let id): "/api/v1/reports/\(id)/extraction/trigger"
+
+        // Access Grants
+        case .accessGrants, .createAccessGrant: "/api/v1/access-grants"
+        case .accessGrantsReceived: "/api/v1/access-grants/received"
+        case .revokeAccessGrant(let id): "/api/v1/access-grants/\(id)"
+
+        // Emergency Contacts
+        case .emergencyContacts, .createEmergencyContact: "/api/v1/emergency-contacts"
+        case .updateEmergencyContact(let id), .deleteEmergencyContact(let id):
+            "/api/v1/emergency-contacts/\(id)"
+
+        // Emergency Access
+        case .requestEmergencyAccess: "/api/v1/emergency-access/request"
+
+        // Consents
+        case .upsertConsent(let purpose): "/api/v1/consents/\(purpose)"
+
+        // Notifications
+        case .notificationPreferences, .updateNotificationPreferences:
+            "/api/v1/notifications/preferences"
+        case .registerDevice: "/api/v1/notifications/devices"
+        case .unregisterDevice(let token): "/api/v1/notifications/devices/\(token)"
+        }
+    }
+
+    var requiresAuth: Bool {
+        switch self {
+        case .socialAuthorize, .socialToken, .otpRequest, .otpVerify, .tokenRefresh:
+            false
+        default:
+            true
+        }
+    }
+
+    var queryItems: [URLQueryItem]? {
+        switch self {
+        case .reportsList(let page, let pageSize, let type, let status, let search):
+            var items = [
+                URLQueryItem(name: "page", value: "\(page)"),
+                URLQueryItem(name: "pageSize", value: "\(pageSize)")
+            ]
+            if let type { items.append(URLQueryItem(name: "reportType", value: type)) }
+            if let status { items.append(URLQueryItem(name: "status", value: status)) }
+            if let search { items.append(URLQueryItem(name: "search", value: search)) }
+            return items
+        default:
+            return nil
+        }
+    }
+}

--- a/AarogyaiOS/Data/Network/APIError.swift
+++ b/AarogyaiOS/Data/Network/APIError.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum APIError: Error, Sendable {
+    case unauthorized
+    case forbidden(code: String?)
+    case registrationRequired
+    case registrationPending
+    case registrationRejected
+    case consentRequired(purpose: String)
+    case notFound
+    case validationError(fields: [FieldError])
+    case rateLimited(retryAfter: TimeInterval?)
+    case serverError(status: Int)
+    case networkError(underlying: any Error)
+    case decodingError(underlying: any Error)
+    case tokenRefreshFailed
+    case unknown(status: Int)
+
+    var isAuthError: Bool {
+        switch self {
+        case .unauthorized, .tokenRefreshFailed: true
+        default: false
+        }
+    }
+}
+
+struct FieldError: Decodable, Sendable {
+    let field: String
+    let message: String
+}
+
+struct ErrorResponse: Decodable, Sendable {
+    let message: String?
+    let code: String?
+    let errors: [FieldError]?
+}

--- a/AarogyaiOS/Data/Network/AuthInterceptor.swift
+++ b/AarogyaiOS/Data/Network/AuthInterceptor.swift
@@ -1,0 +1,66 @@
+import Foundation
+import OSLog
+
+actor AuthInterceptor {
+    private let tokenStore: any TokenStoring
+    private let refreshToken: @Sendable () async throws -> AuthTokens
+    private var isRefreshing = false
+    private var pendingContinuations: [CheckedContinuation<String, any Error>] = []
+
+    init(
+        tokenStore: any TokenStoring,
+        refreshToken: @Sendable @escaping () async throws -> AuthTokens
+    ) {
+        self.tokenStore = tokenStore
+        self.refreshToken = refreshToken
+    }
+
+    func intercept(_ request: URLRequest) async throws -> URLRequest {
+        let token = try await getValidToken()
+        var request = request
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    private func getValidToken() async throws -> String {
+        if isRefreshing {
+            return try await withCheckedThrowingContinuation { continuation in
+                pendingContinuations.append(continuation)
+            }
+        }
+
+        do {
+            let token = try await tokenStore.accessToken()
+            return token
+        } catch {
+            return try await performRefresh()
+        }
+    }
+
+    private func performRefresh() async throws -> String {
+        isRefreshing = true
+        defer {
+            isRefreshing = false
+        }
+
+        do {
+            let tokens = try await refreshToken()
+            let accessToken = tokens.accessToken
+
+            for continuation in pendingContinuations {
+                continuation.resume(returning: accessToken)
+            }
+            pendingContinuations.removeAll()
+
+            return accessToken
+        } catch {
+            for continuation in pendingContinuations {
+                continuation.resume(throwing: APIError.tokenRefreshFailed)
+            }
+            pendingContinuations.removeAll()
+
+            Logger.auth.error("Token refresh failed")
+            throw APIError.tokenRefreshFailed
+        }
+    }
+}

--- a/AarogyaiOS/Data/Network/DTOs/Auth/OtpDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Auth/OtpDTO.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct OtpRequestDTO: Encodable, Sendable {
+    let phone: String
+}
+
+struct OtpVerifyRequest: Encodable, Sendable {
+    let phone: String
+    let otp: String
+}

--- a/AarogyaiOS/Data/Network/DTOs/Auth/RefreshTokenDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Auth/RefreshTokenDTO.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct RefreshTokenRequest: Encodable, Sendable {
+    let refreshToken: String
+}

--- a/AarogyaiOS/Data/Network/DTOs/Auth/SocialAuthDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Auth/SocialAuthDTO.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct SocialAuthorizeRequest: Encodable, Sendable {
+    let provider: String
+    let codeChallenge: String
+    let codeChallengeMethod: String
+    let state: String
+    let redirectUri: String
+}
+
+struct SocialAuthorizeResponse: Decodable, Sendable {
+    let authorizeUrl: String
+}
+
+struct SocialTokenRequest: Encodable, Sendable {
+    let code: String
+    let codeVerifier: String
+    let state: String
+    let redirectUri: String
+}
+
+struct TokenResponse: Decodable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let idToken: String
+    let expiresIn: Int
+    let tokenType: String
+}

--- a/AarogyaiOS/Data/Network/DTOs/PaginatedDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/PaginatedDTO.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct PaginatedDTO<T: Decodable & Sendable>: Decodable, Sendable {
+    let page: Int
+    let pageSize: Int
+    let totalCount: Int
+    let items: [T]
+}

--- a/AarogyaiOS/Data/Network/DTOs/User/UserProfileDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/User/UserProfileDTO.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct UserProfileResponse: Decodable, Sendable {
+    let id: String
+    let firstName: String
+    let lastName: String
+    let email: String
+    let phone: String
+    let address: String?
+    let bloodGroup: String?
+    let dateOfBirth: String?
+    let gender: String?
+    let role: String
+    let registrationStatus: String
+    let isAadhaarVerified: Bool
+    let aadhaarRefToken: String?
+    let doctorProfile: DoctorProfileDTO?
+    let labTechnicianProfile: LabTechProfileDTO?
+    let createdAt: String
+    let updatedAt: String
+}
+
+struct DoctorProfileDTO: Decodable, Sendable {
+    let id: String
+    let medicalLicenseNumber: String
+    let specialization: String
+    let clinicOrHospitalName: String?
+    let clinicAddress: String?
+}
+
+struct LabTechProfileDTO: Decodable, Sendable {
+    let id: String
+    let labName: String
+    let labLicenseNumber: String?
+    let nablAccreditationId: String?
+}
+
+struct UpdateProfileRequest: Encodable, Sendable {
+    let firstName: String
+    let lastName: String
+    let email: String
+    let phone: String
+    let address: String?
+    let bloodGroup: String?
+    let dateOfBirth: String?
+    let gender: String?
+}
+
+struct RegisterUserRequest: Encodable, Sendable {
+    let firstName: String
+    let lastName: String
+    let email: String
+    let phone: String
+    let dateOfBirth: String?
+    let gender: String?
+    let bloodGroup: String?
+    let address: String?
+    let role: String
+    let doctorProfile: DoctorProfileInputDTO?
+    let labTechnicianProfile: LabTechProfileInputDTO?
+    let consents: [ConsentInputDTO]
+}
+
+struct DoctorProfileInputDTO: Encodable, Sendable {
+    let medicalLicenseNumber: String
+    let specialization: String
+    let clinicOrHospitalName: String?
+    let clinicAddress: String?
+}
+
+struct LabTechProfileInputDTO: Encodable, Sendable {
+    let labName: String
+    let labLicenseNumber: String?
+    let nablAccreditationId: String?
+}
+
+struct ConsentInputDTO: Encodable, Sendable {
+    let purpose: String
+    let isGranted: Bool
+}
+
+struct RegistrationStatusResponse: Decodable, Sendable {
+    let registrationStatus: String
+}

--- a/AarogyaiOS/Data/Network/HTTPMethod.swift
+++ b/AarogyaiOS/Data/Network/HTTPMethod.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/AarogyaiOS/Data/Network/Mappers/UserMapper.swift
+++ b/AarogyaiOS/Data/Network/Mappers/UserMapper.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+enum UserMapper {
+    static func toDomain(_ dto: UserProfileResponse) -> User {
+        User(
+            id: dto.id,
+            firstName: dto.firstName,
+            lastName: dto.lastName,
+            email: dto.email,
+            phone: dto.phone,
+            address: dto.address,
+            bloodGroup: dto.bloodGroup.flatMap { BloodGroup(rawValue: $0) },
+            dateOfBirth: dto.dateOfBirth.flatMap { Date(iso8601: $0) },
+            gender: dto.gender.flatMap { Gender(rawValue: $0) },
+            role: UserRole(rawValue: dto.role) ?? .patient,
+            registrationStatus: RegistrationStatus(rawValue: dto.registrationStatus) ?? .registered,
+            isAadhaarVerified: dto.isAadhaarVerified,
+            aadhaarRefToken: dto.aadhaarRefToken,
+            doctorProfile: dto.doctorProfile.map { toDomain($0) },
+            labTechProfile: dto.labTechnicianProfile.map { toDomain($0) },
+            createdAt: Date(iso8601: dto.createdAt) ?? .now,
+            updatedAt: Date(iso8601: dto.updatedAt) ?? .now
+        )
+    }
+
+    static func toDomain(_ dto: DoctorProfileDTO) -> DoctorProfile {
+        DoctorProfile(
+            id: dto.id,
+            medicalLicenseNumber: dto.medicalLicenseNumber,
+            specialization: dto.specialization,
+            clinicOrHospitalName: dto.clinicOrHospitalName,
+            clinicAddress: dto.clinicAddress
+        )
+    }
+
+    static func toDomain(_ dto: LabTechProfileDTO) -> LabTechnicianProfile {
+        LabTechnicianProfile(
+            id: dto.id,
+            labName: dto.labName,
+            labLicenseNumber: dto.labLicenseNumber,
+            nablAccreditationId: dto.nablAccreditationId
+        )
+    }
+
+    static func toTokens(_ dto: TokenResponse) -> AuthTokens {
+        AuthTokens(
+            accessToken: dto.accessToken,
+            refreshToken: dto.refreshToken,
+            idToken: dto.idToken,
+            expiresIn: dto.expiresIn
+        )
+    }
+}

--- a/AarogyaiOS/Infrastructure/Keychain/KeychainService.swift
+++ b/AarogyaiOS/Infrastructure/Keychain/KeychainService.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Security
+
+enum KeychainError: Error, Sendable {
+    case itemNotFound
+    case duplicateItem
+    case unexpectedStatus(OSStatus)
+    case encodingFailed
+    case decodingFailed
+}
+
+struct KeychainService: Sendable {
+    private let service: String
+
+    init(service: String = Constants.Keychain.serviceName) {
+        self.service = service
+    }
+
+    func save(_ data: Data, for key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        if status == errSecDuplicateItem {
+            try update(data, for: key)
+        } else if status != errSecSuccess {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func save(_ string: String, for key: String) throws {
+        guard let data = string.data(using: .utf8) else {
+            throw KeychainError.encodingFailed
+        }
+        try save(data, for: key)
+    }
+
+    func read(key: String) throws -> Data {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            if status == errSecItemNotFound {
+                throw KeychainError.itemNotFound
+            }
+            throw KeychainError.unexpectedStatus(status)
+        }
+
+        return data
+    }
+
+    func readString(key: String) throws -> String {
+        let data = try read(key: key)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw KeychainError.decodingFailed
+        }
+        return string
+    }
+
+    func update(_ data: Data, for key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func delete(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func deleteAll() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/AarogyaiOS/Infrastructure/Keychain/TokenStore.swift
+++ b/AarogyaiOS/Infrastructure/Keychain/TokenStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct TokenStore: TokenStoring {
+    private let keychain: KeychainService
+
+    init(keychain: KeychainService = KeychainService()) {
+        self.keychain = keychain
+    }
+
+    func store(_ tokens: AuthTokens) async throws {
+        try keychain.save(tokens.accessToken, for: Constants.Keychain.accessTokenKey)
+        try keychain.save(tokens.refreshToken, for: Constants.Keychain.refreshTokenKey)
+        try keychain.save(tokens.idToken, for: Constants.Keychain.idTokenKey)
+    }
+
+    func accessToken() async throws -> String {
+        try keychain.readString(key: Constants.Keychain.accessTokenKey)
+    }
+
+    func refreshToken() async throws -> String {
+        try keychain.readString(key: Constants.Keychain.refreshTokenKey)
+    }
+
+    func idToken() async throws -> String {
+        try keychain.readString(key: Constants.Keychain.idTokenKey)
+    }
+
+    func clearAll() async throws {
+        try keychain.deleteAll()
+    }
+}


### PR DESCRIPTION
## Summary
- `APIClient` with URLSession async/await, snake_case JSON, and full HTTP error mapping
- `APIEndpoint` enum for all 32 API routes with type-safe paths and query params
- `AuthInterceptor` (actor) with Bearer token attachment and concurrent refresh coalescing
- `KeychainService` using native Security framework (no third-party wrapper)
- `TokenStore` implementing `TokenStoring` protocol for access/refresh/ID tokens
- Auth DTOs: Social auth, OTP, token refresh/response
- User DTOs: Profile, registration, doctor/lab tech profiles
- `PaginatedDTO<T>` generic wrapper
- `UserMapper` for DTO-to-domain conversion

Closes #14, Closes #15, Closes #16, Closes #19, Closes #20, Closes #21

## Test plan
- [x] Project builds with zero errors
- [x] Unit tests pass
- [x] All types Sendable-compatible under strict concurrency
- [x] SwiftLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)