### PR TITLE
feat(data): add SwiftData persistence layer with cache-first pattern

### DIFF
--- a/AarogyaiOS/Data/CachePolicy.swift
+++ b/AarogyaiOS/Data/CachePolicy.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+enum CachePolicy: Sendable {
+    case cacheFirst(ttl: TimeInterval)
+    case networkFirst(fallbackTtl: TimeInterval)
+}
+
+struct CachedData<T: Sendable>: Sendable {
+    let data: T
+    let fetchedAt: Date
+    let isStale: Bool
+
+    var isExpired: Bool { isStale }
+}
+
+actor CacheHelper {
+    private let networkMonitor: NetworkMonitor
+
+    init(networkMonitor: NetworkMonitor) {
+        self.networkMonitor = networkMonitor
+    }
+
+    func resolve<T: Sendable>(
+        policy: CachePolicy,
+        fetch: @Sendable () async throws -> T,
+        loadCache: @Sendable () async throws -> (T, Date)?,
+        saveCache: @Sendable (T) async throws -> Void
+    ) async throws -> CachedData<T> {
+        switch policy {
+        case .cacheFirst(let ttl):
+            return try await cacheFirst(
+                ttl: ttl,
+                fetch: fetch,
+                loadCache: loadCache,
+                saveCache: saveCache
+            )
+        case .networkFirst(let fallbackTtl):
+            return try await networkFirst(
+                fallbackTtl: fallbackTtl,
+                fetch: fetch,
+                loadCache: loadCache,
+                saveCache: saveCache
+            )
+        }
+    }
+
+    private func cacheFirst<T: Sendable>(
+        ttl: TimeInterval,
+        fetch: @Sendable () async throws -> T,
+        loadCache: @Sendable () async throws -> (T, Date)?,
+        saveCache: @Sendable (T) async throws -> Void
+    ) async throws -> CachedData<T> {
+        if let (cached, fetchedAt) = try await loadCache() {
+            let isStale = Date.now.timeIntervalSince(fetchedAt) > ttl
+            if !isStale {
+                return CachedData(data: cached, fetchedAt: fetchedAt, isStale: false)
+            }
+        }
+
+        let isOnline = await networkMonitor.isConnected
+        if isOnline {
+            let fresh = try await fetch()
+            try? await saveCache(fresh)
+            return CachedData(data: fresh, fetchedAt: .now, isStale: false)
+        }
+
+        if let (cached, fetchedAt) = try await loadCache() {
+            return CachedData(data: cached, fetchedAt: fetchedAt, isStale: true)
+        }
+
+        throw CacheError.noDataAvailable
+    }
+
+    private func networkFirst<T: Sendable>(
+        fallbackTtl: TimeInterval,
+        fetch: @Sendable () async throws -> T,
+        loadCache: @Sendable () async throws -> (T, Date)?,
+        saveCache: @Sendable (T) async throws -> Void
+    ) async throws -> CachedData<T> {
+        let isOnline = await networkMonitor.isConnected
+        if isOnline {
+            do {
+                let fresh = try await fetch()
+                try? await saveCache(fresh)
+                return CachedData(data: fresh, fetchedAt: .now, isStale: false)
+            } catch {
+                if let (cached, fetchedAt) = try await loadCache(),
+                   Date.now.timeIntervalSince(fetchedAt) <= fallbackTtl {
+                    return CachedData(data: cached, fetchedAt: fetchedAt, isStale: true)
+                }
+                throw error
+            }
+        }
+
+        if let (cached, fetchedAt) = try await loadCache() {
+            return CachedData(data: cached, fetchedAt: fetchedAt, isStale: true)
+        }
+
+        throw CacheError.noDataAvailable
+    }
+}
+
+enum CacheError: Error, Sendable {
+    case noDataAvailable
+}

--- a/AarogyaiOS/Data/Local/LocalDataSource.swift
+++ b/AarogyaiOS/Data/Local/LocalDataSource.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftData
+import OSLog
+
+@ModelActor
+actor LocalDataSource {
+
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            CachedReport.self,
+            CachedUser.self,
+            CachedEmergencyContact.self
+        ])
+        let config = ModelConfiguration("AarogyaCache", isStoredInMemoryOnly: false)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    // MARK: - Generic Fetch
+
+    func fetch<T: PersistentModel>(_ descriptor: FetchDescriptor<T>) throws -> [T] {
+        try modelContext.fetch(descriptor)
+    }
+
+    func fetchOne<T: PersistentModel>(_ descriptor: FetchDescriptor<T>) throws -> T? {
+        var limited = descriptor
+        limited.fetchLimit = 1
+        return try modelContext.fetch(limited).first
+    }
+
+    func fetchCount<T: PersistentModel>(_ descriptor: FetchDescriptor<T>) throws -> Int {
+        try modelContext.fetchCount(descriptor)
+    }
+
+    // MARK: - Insert
+
+    func insert<T: PersistentModel>(_ model: T) throws {
+        modelContext.insert(model)
+        try modelContext.save()
+    }
+
+    func insertBatch<T: PersistentModel>(_ models: [T]) throws {
+        for model in models {
+            modelContext.insert(model)
+        }
+        try modelContext.save()
+    }
+
+    // MARK: - Delete
+
+    func delete<T: PersistentModel>(_ model: T) throws {
+        modelContext.delete(model)
+        try modelContext.save()
+    }
+
+    func deleteAll<T: PersistentModel>(_ type: T.Type) throws {
+        try modelContext.delete(model: type)
+        try modelContext.save()
+    }
+
+    // MARK: - Save
+
+    func save() throws {
+        try modelContext.save()
+    }
+
+    // MARK: - Report Helpers
+
+    func fetchCachedReports() throws -> [CachedReport] {
+        let descriptor = FetchDescriptor<CachedReport>(
+            sortBy: [SortDescriptor(\.uploadedAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    func fetchCachedReport(id: String) throws -> CachedReport? {
+        let descriptor = FetchDescriptor<CachedReport>(
+            predicate: #Predicate { $0.reportId == id }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func syncReports(_ reports: [Report]) throws {
+        try modelContext.delete(model: CachedReport.self)
+        for report in reports {
+            modelContext.insert(CachedReport(from: report))
+        }
+        try modelContext.save()
+    }
+
+    // MARK: - User Helpers
+
+    func fetchCachedUser(id: String) throws -> CachedUser? {
+        let descriptor = FetchDescriptor<CachedUser>(
+            predicate: #Predicate { $0.userId == id }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func syncUser(_ user: User) throws {
+        if let existing = try fetchCachedUser(id: user.id) {
+            modelContext.delete(existing)
+        }
+        modelContext.insert(CachedUser(from: user))
+        try modelContext.save()
+    }
+
+    // MARK: - Emergency Contact Helpers
+
+    func fetchCachedEmergencyContacts() throws -> [CachedEmergencyContact] {
+        let descriptor = FetchDescriptor<CachedEmergencyContact>(
+            sortBy: [SortDescriptor(\.name)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    func syncEmergencyContacts(_ contacts: [EmergencyContact]) throws {
+        try modelContext.delete(model: CachedEmergencyContact.self)
+        for contact in contacts {
+            modelContext.insert(CachedEmergencyContact(from: contact))
+        }
+        try modelContext.save()
+    }
+}

--- a/AarogyaiOS/Data/Local/SwiftDataModels/CachedEmergencyContact.swift
+++ b/AarogyaiOS/Data/Local/SwiftDataModels/CachedEmergencyContact.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedEmergencyContact {
+    @Attribute(.unique) var contactId: String
+    var name: String
+    var phone: String
+    var relationship: String
+    var isPrimary: Bool
+    var lastFetchedAt: Date
+
+    init(
+        contactId: String,
+        name: String,
+        phone: String,
+        relationship: String,
+        isPrimary: Bool,
+        lastFetchedAt: Date = .now
+    ) {
+        self.contactId = contactId
+        self.name = name
+        self.phone = phone
+        self.relationship = relationship
+        self.isPrimary = isPrimary
+        self.lastFetchedAt = lastFetchedAt
+    }
+
+    convenience init(from contact: EmergencyContact) {
+        self.init(
+            contactId: contact.id,
+            name: contact.name,
+            phone: contact.phone,
+            relationship: contact.relationship.rawValue,
+            isPrimary: contact.isPrimary
+        )
+    }
+
+    func toDomain() -> EmergencyContact {
+        EmergencyContact(
+            id: contactId,
+            name: name,
+            phone: phone,
+            relationship: Relationship(rawValue: relationship) ?? .other,
+            isPrimary: isPrimary,
+            createdAt: lastFetchedAt,
+            updatedAt: lastFetchedAt
+        )
+    }
+}

--- a/AarogyaiOS/Data/Local/SwiftDataModels/CachedReport.swift
+++ b/AarogyaiOS/Data/Local/SwiftDataModels/CachedReport.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedReport {
+    @Attribute(.unique) var reportId: String
+    var reportNumber: String
+    var title: String
+    var reportType: String
+    var status: String
+    var patientId: String
+    var uploadedAt: Date
+    var labName: String?
+    var highlightParameter: String?
+    var lastFetchedAt: Date
+
+    init(
+        reportId: String,
+        reportNumber: String,
+        title: String,
+        reportType: String,
+        status: String,
+        patientId: String,
+        uploadedAt: Date,
+        labName: String?,
+        highlightParameter: String?,
+        lastFetchedAt: Date = .now
+    ) {
+        self.reportId = reportId
+        self.reportNumber = reportNumber
+        self.title = title
+        self.reportType = reportType
+        self.status = status
+        self.patientId = patientId
+        self.uploadedAt = uploadedAt
+        self.labName = labName
+        self.highlightParameter = highlightParameter
+        self.lastFetchedAt = lastFetchedAt
+    }
+
+    convenience init(from report: Report) {
+        self.init(
+            reportId: report.id,
+            reportNumber: report.reportNumber,
+            title: report.title,
+            reportType: report.reportType.rawValue,
+            status: report.status.rawValue,
+            patientId: report.patientId,
+            uploadedAt: report.uploadedAt,
+            labName: report.labName,
+            highlightParameter: report.highlightParameter
+        )
+    }
+
+    func toDomain() -> Report {
+        Report(
+            id: reportId,
+            reportNumber: reportNumber,
+            title: title,
+            reportType: ReportType(rawValue: reportType) ?? .other,
+            status: ReportStatus(rawValue: status) ?? .uploaded,
+            patientId: patientId,
+            doctorId: nil,
+            doctorName: nil,
+            labName: labName,
+            collectedAt: nil,
+            reportedAt: nil,
+            uploadedAt: uploadedAt,
+            notes: nil,
+            fileStorageKey: nil,
+            fileType: nil,
+            fileSizeBytes: nil,
+            checksumSha256: nil,
+            parameters: [],
+            extraction: nil,
+            highlightParameter: highlightParameter,
+            createdAt: uploadedAt,
+            updatedAt: uploadedAt
+        )
+    }
+}

--- a/AarogyaiOS/Data/Local/SwiftDataModels/CachedUser.swift
+++ b/AarogyaiOS/Data/Local/SwiftDataModels/CachedUser.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedUser {
+    @Attribute(.unique) var userId: String
+    var firstName: String
+    var lastName: String
+    var email: String
+    var phone: String
+    var role: String
+    var registrationStatus: String
+    var lastFetchedAt: Date
+
+    init(
+        userId: String,
+        firstName: String,
+        lastName: String,
+        email: String,
+        phone: String,
+        role: String,
+        registrationStatus: String,
+        lastFetchedAt: Date = .now
+    ) {
+        self.userId = userId
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.phone = phone
+        self.role = role
+        self.registrationStatus = registrationStatus
+        self.lastFetchedAt = lastFetchedAt
+    }
+
+    convenience init(from user: User) {
+        self.init(
+            userId: user.id,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email,
+            phone: user.phone,
+            role: user.role.rawValue,
+            registrationStatus: user.registrationStatus.rawValue
+        )
+    }
+
+    func toDomain() -> User {
+        User(
+            id: userId,
+            firstName: firstName,
+            lastName: lastName,
+            email: email,
+            phone: phone,
+            address: nil,
+            bloodGroup: nil,
+            dateOfBirth: nil,
+            gender: nil,
+            role: UserRole(rawValue: role) ?? .patient,
+            registrationStatus: RegistrationStatus(rawValue: registrationStatus) ?? .approved,
+            isAadhaarVerified: false,
+            aadhaarRefToken: nil,
+            doctorProfile: nil,
+            labTechProfile: nil,
+            createdAt: lastFetchedAt,
+            updatedAt: lastFetchedAt
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add SwiftData `@Model` classes: `CachedReport`, `CachedUser`, `CachedEmergencyContact` with `@Attribute(.unique)` IDs and `lastFetchedAt` for TTL
- Add `LocalDataSource` actor using `@ModelActor` for thread-safe SwiftData CRUD with typed helpers for reports, users, and contacts
- Add `CachePolicy` enum (`cacheFirst`/`networkFirst`) and `CacheHelper` actor implementing TTL-based cache resolution with offline fallback

## Test plan
- [x] Project builds successfully
- [x] All tests pass
- [ ] CI pipeline passes

Closes #28, closes #29, closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)