### PR TITLE
feat(presentation): add app entry, DI container, navigation, and design tokens

### DIFF
--- a/AarogyaiOS/App/AarogyaApp.swift
+++ b/AarogyaiOS/App/AarogyaApp.swift
@@ -3,15 +3,87 @@ import SwiftData
 
 @main
 struct AarogyaApp: App {
+    @State private var container = DependencyContainer()
+    @State private var coordinator: AppCoordinator?
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            RootView(container: container)
+                .modelContainer(container.modelContainer)
         }
     }
 }
 
-struct ContentView: View {
+struct RootView: View {
+    let container: DependencyContainer
+    @State private var coordinator: AppCoordinator
+
+    init(container: DependencyContainer) {
+        self.container = container
+        self._coordinator = State(initialValue: AppCoordinator(container: container))
+    }
+
     var body: some View {
-        Text("Aarogya")
+        Group {
+            switch coordinator.state {
+            case .loading:
+                ProgressView("Loading…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .sereneBloomBackground()
+            case .unauthenticated:
+                PlaceholderAuthView {
+                    Task { await coordinator.handleLogin() }
+                }
+            case .pendingApproval:
+                PlaceholderStatusView(message: "Your registration is pending approval.")
+            case .rejected:
+                PlaceholderStatusView(message: "Your registration was not approved.")
+            case .authenticated:
+                TabCoordinator()
+            }
+        }
+        .environment(coordinator)
+        .task {
+            await coordinator.checkAuthState()
+        }
+    }
+}
+
+// MARK: - Placeholder Views (replaced by real views in later issues)
+
+private struct PlaceholderAuthView: View {
+    let onLogin: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Aarogya")
+                .font(Typography.largeTitle)
+            Text("Sign in to continue")
+                .font(Typography.body)
+                .foregroundStyle(.secondary)
+            Button("Sign In") { onLogin() }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.Fallback.brandPrimary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .sereneBloomBackground()
+    }
+}
+
+private struct PlaceholderStatusView: View {
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "clock.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.Fallback.brandAccent)
+            Text(message)
+                .font(Typography.body)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .sereneBloomBackground()
     }
 }

--- a/AarogyaiOS/App/DependencyContainer.swift
+++ b/AarogyaiOS/App/DependencyContainer.swift
@@ -1,0 +1,142 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class DependencyContainer {
+    // MARK: - Infrastructure
+
+    let networkMonitor: NetworkMonitor
+    let keychainService: KeychainService
+    let tokenStore: TokenStore
+    let s3UploadService: S3UploadService
+    let pushService: any PushNotificationService
+
+    // MARK: - Data
+
+    let modelContainer: ModelContainer
+    let localDataSource: LocalDataSource
+    let apiClient: APIClient
+    let authInterceptor: AuthInterceptor
+
+    // MARK: - Repositories
+
+    let authRepository: any AuthRepository
+    let userRepository: any UserRepository
+    let reportRepository: any ReportRepository
+    let accessGrantRepository: any AccessGrantRepository
+    let emergencyContactRepository: any EmergencyContactRepository
+    let consentRepository: any ConsentRepository
+    let notificationRepository: any NotificationRepository
+
+    // MARK: - Use Cases — Auth
+
+    let loginUseCase: LoginUseCase
+    let logoutUseCase: LogoutUseCase
+    let refreshTokenUseCase: RefreshTokenUseCase
+    let registerUserUseCase: RegisterUserUseCase
+    let getCurrentUserUseCase: GetCurrentUserUseCase
+    let updateProfileUseCase: UpdateProfileUseCase
+    let checkRegistrationStatusUseCase: CheckRegistrationStatusUseCase
+    let verifyAadhaarUseCase: VerifyAadhaarUseCase
+    let exportDataUseCase: ExportDataUseCase
+    let requestAccountDeletionUseCase: RequestAccountDeletionUseCase
+
+    // MARK: - Use Cases — Reports
+
+    let fetchReportsUseCase: FetchReportsUseCase
+    let uploadReportUseCase: UploadReportUseCase
+    let deleteReportUseCase: DeleteReportUseCase
+    let downloadReportUseCase: DownloadReportUseCase
+
+    // MARK: - Use Cases — Access Grants
+
+    let fetchAccessGrantsUseCase: FetchAccessGrantsUseCase
+    let createAccessGrantUseCase: CreateAccessGrantUseCase
+    let revokeAccessGrantUseCase: RevokeAccessGrantUseCase
+
+    // MARK: - Use Cases — Emergency Contacts
+
+    let fetchEmergencyContactsUseCase: FetchEmergencyContactsUseCase
+    let manageEmergencyContactUseCase: ManageEmergencyContactUseCase
+
+    // MARK: - Use Cases — Consents & Notifications
+
+    let manageConsentsUseCase: ManageConsentsUseCase
+    let manageNotificationsUseCase: ManageNotificationsUseCase
+
+    init() {
+        // Infrastructure
+        networkMonitor = NetworkMonitor()
+        networkMonitor.start()
+
+        keychainService = KeychainService(service: Constants.Keychain.serviceName)
+        tokenStore = TokenStore(keychain: keychainService)
+
+        s3UploadService = S3UploadService()
+        pushService = MockPushService()
+
+        // Persistence
+        do {
+            modelContainer = try LocalDataSource.makeContainer()
+        } catch {
+            fatalError("Failed to create ModelContainer: \(error)")
+        }
+        localDataSource = LocalDataSource(modelContainer: modelContainer)
+
+        // Networking
+        let tokenStoreRef: any TokenStoring = tokenStore
+        authInterceptor = AuthInterceptor(
+            tokenStore: tokenStoreRef,
+            refreshToken: {
+                let refreshClient = APIClient(baseURL: Constants.API.baseURL)
+                let repo = DefaultAuthRepository(apiClient: refreshClient, tokenStore: tokenStoreRef)
+                let currentRefreshToken = try await tokenStoreRef.refreshToken()
+                return try await repo.refreshToken(refreshToken: currentRefreshToken)
+            }
+        )
+        apiClient = APIClient(
+            baseURL: Constants.API.baseURL,
+            interceptor: authInterceptor
+        )
+
+        // Repositories
+        authRepository = DefaultAuthRepository(apiClient: apiClient, tokenStore: tokenStore)
+        userRepository = DefaultUserRepository(apiClient: apiClient)
+        reportRepository = DefaultReportRepository(apiClient: apiClient)
+        accessGrantRepository = DefaultAccessGrantRepository(apiClient: apiClient)
+        emergencyContactRepository = DefaultEmergencyContactRepository(apiClient: apiClient)
+        consentRepository = DefaultConsentRepository(apiClient: apiClient)
+        notificationRepository = DefaultNotificationRepository(apiClient: apiClient)
+
+        // Use Cases — Auth
+        loginUseCase = LoginUseCase(authRepository: authRepository, tokenStore: tokenStore)
+        logoutUseCase = LogoutUseCase(authRepository: authRepository, tokenStore: tokenStore)
+        refreshTokenUseCase = RefreshTokenUseCase(authRepository: authRepository, tokenStore: tokenStore)
+        registerUserUseCase = RegisterUserUseCase(userRepository: userRepository)
+        getCurrentUserUseCase = GetCurrentUserUseCase(userRepository: userRepository)
+        updateProfileUseCase = UpdateProfileUseCase(userRepository: userRepository)
+        checkRegistrationStatusUseCase = CheckRegistrationStatusUseCase(userRepository: userRepository)
+        verifyAadhaarUseCase = VerifyAadhaarUseCase(userRepository: userRepository)
+        exportDataUseCase = ExportDataUseCase(userRepository: userRepository)
+        requestAccountDeletionUseCase = RequestAccountDeletionUseCase(userRepository: userRepository)
+
+        // Use Cases — Reports
+        fetchReportsUseCase = FetchReportsUseCase(reportRepository: reportRepository)
+        uploadReportUseCase = UploadReportUseCase(reportRepository: reportRepository, uploadService: s3UploadService)
+        deleteReportUseCase = DeleteReportUseCase(reportRepository: reportRepository)
+        downloadReportUseCase = DownloadReportUseCase(reportRepository: reportRepository)
+
+        // Use Cases — Access Grants
+        fetchAccessGrantsUseCase = FetchAccessGrantsUseCase(accessGrantRepository: accessGrantRepository)
+        createAccessGrantUseCase = CreateAccessGrantUseCase(accessGrantRepository: accessGrantRepository)
+        revokeAccessGrantUseCase = RevokeAccessGrantUseCase(accessGrantRepository: accessGrantRepository)
+
+        // Use Cases — Emergency Contacts
+        fetchEmergencyContactsUseCase = FetchEmergencyContactsUseCase(emergencyContactRepository: emergencyContactRepository)
+        manageEmergencyContactUseCase = ManageEmergencyContactUseCase(emergencyContactRepository: emergencyContactRepository)
+
+        // Use Cases — Consents & Notifications
+        manageConsentsUseCase = ManageConsentsUseCase(consentRepository: consentRepository)
+        manageNotificationsUseCase = ManageNotificationsUseCase(notificationRepository: notificationRepository)
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import OSLog
+
+@Observable
+@MainActor
+final class AppCoordinator {
+    enum AppState: Sendable {
+        case loading
+        case unauthenticated
+        case pendingApproval
+        case rejected
+        case authenticated(User)
+    }
+
+    var state: AppState = .loading
+
+    private let container: DependencyContainer
+
+    init(container: DependencyContainer) {
+        self.container = container
+    }
+
+    func checkAuthState() async {
+        do {
+            let user = try await container.getCurrentUserUseCase.execute()
+            switch user.registrationStatus {
+            case .registered, .pendingApproval:
+                state = .pendingApproval
+            case .rejected:
+                state = .rejected
+            case .approved:
+                state = .authenticated(user)
+            }
+        } catch let error as APIError {
+            switch error {
+            case .unauthorized, .tokenRefreshFailed:
+                state = .unauthenticated
+            case .registrationRequired:
+                state = .unauthenticated
+            case .registrationPending:
+                state = .pendingApproval
+            case .registrationRejected:
+                state = .rejected
+            default:
+                Logger.auth.error("Auth check failed: \(error)")
+                state = .unauthenticated
+            }
+        } catch {
+            Logger.auth.error("Auth check failed: \(error)")
+            state = .unauthenticated
+        }
+    }
+
+    func handleLogin() async {
+        await checkAuthState()
+    }
+
+    func handleLogout() async {
+        do {
+            try await container.logoutUseCase.execute()
+        } catch {
+            Logger.auth.error("Logout error: \(error)")
+        }
+        state = .unauthenticated
+    }
+
+    func handleRegistrationComplete() async {
+        await checkAuthState()
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/Route.swift
+++ b/AarogyaiOS/Presentation/Navigation/Route.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum Route: Hashable {
+    // Reports
+    case reportDetail(id: String)
+    case reportUpload
+
+    // Access Grants
+    case createAccessGrant
+
+    // Emergency
+    case emergencyContactForm(contact: EmergencyContact?)
+
+    // Settings
+    case profileEdit
+    case consents
+    case notificationPreferences
+    case account
+
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .reportDetail(let id):
+            hasher.combine("reportDetail")
+            hasher.combine(id)
+        case .reportUpload:
+            hasher.combine("reportUpload")
+        case .createAccessGrant:
+            hasher.combine("createAccessGrant")
+        case .emergencyContactForm(let contact):
+            hasher.combine("emergencyContactForm")
+            hasher.combine(contact?.id)
+        case .profileEdit:
+            hasher.combine("profileEdit")
+        case .consents:
+            hasher.combine("consents")
+        case .notificationPreferences:
+            hasher.combine("notificationPreferences")
+        case .account:
+            hasher.combine("account")
+        }
+    }
+
+    static func == (lhs: Route, rhs: Route) -> Bool {
+        switch (lhs, rhs) {
+        case (.reportDetail(let lhsId), .reportDetail(let rhsId)): lhsId == rhsId
+        case (.reportUpload, .reportUpload): true
+        case (.createAccessGrant, .createAccessGrant): true
+        case (.emergencyContactForm(let lhsContact), .emergencyContactForm(let rhsContact)):
+            lhsContact?.id == rhsContact?.id
+        case (.profileEdit, .profileEdit): true
+        case (.consents, .consents): true
+        case (.notificationPreferences, .notificationPreferences): true
+        case (.account, .account): true
+        default: false
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+enum AppTab: String, CaseIterable, Sendable {
+    case reports
+    case access
+    case emergency
+    case settings
+}
+
+struct TabCoordinator: View {
+    @State private var selectedTab: AppTab = .reports
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            Tab("Reports", systemImage: "doc.text", value: .reports) {
+                NavigationStack {
+                    PlaceholderView(title: "Reports")
+                }
+            }
+
+            Tab("Access", systemImage: "person.2", value: .access) {
+                NavigationStack {
+                    PlaceholderView(title: "Access Grants")
+                }
+            }
+
+            Tab("Emergency", systemImage: "phone.fill", value: .emergency) {
+                NavigationStack {
+                    PlaceholderView(title: "Emergency Contacts")
+                }
+            }
+
+            Tab("Settings", systemImage: "gearshape", value: .settings) {
+                NavigationStack {
+                    PlaceholderView(title: "Settings")
+                }
+            }
+        }
+        .tabBarMinimizeBehavior(.onScrollDown)
+    }
+}
+
+private struct PlaceholderView: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.title)
+            .navigationTitle(title)
+    }
+}

--- a/AarogyaiOS/Presentation/SharedComponents/Theme/ColorTokens.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Theme/ColorTokens.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+extension Color {
+    // MARK: - Brand
+
+    static let brandPrimary = Color("brand.primary", bundle: .main)
+    static let brandPrimaryLight = Color("brand.primaryLight", bundle: .main)
+    static let brandSecondary = Color("brand.secondary", bundle: .main)
+    static let brandAccent = Color("brand.accent", bundle: .main)
+
+    // MARK: - Backgrounds
+
+    static let bgPrimary = Color("bg.primary", bundle: .main)
+    static let bgSecondary = Color("bg.secondary", bundle: .main)
+    static let bgGradientStart = Color("bg.gradient.start", bundle: .main)
+    static let bgGradientEnd = Color("bg.gradient.end", bundle: .main)
+
+    // MARK: - Text
+
+    static let textPrimary = Color("text.primary", bundle: .main)
+    static let textSecondary = Color("text.secondary", bundle: .main)
+    static let textTertiary = Color("text.tertiary", bundle: .main)
+
+    // MARK: - Status
+
+    static let statusNormal = Color("status.normal", bundle: .main)
+    static let statusWarning = Color("status.warning", bundle: .main)
+    static let statusCritical = Color("status.critical", bundle: .main)
+    static let statusInfo = Color("status.info", bundle: .main)
+
+    // MARK: - Border
+
+    static let borderDefault = Color("border.default", bundle: .main)
+
+    // MARK: - Hex Fallbacks
+
+    init(hex: UInt, opacity: Double = 1.0) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: opacity
+        )
+    }
+}
+
+// MARK: - Fallback colors (used when asset catalog isn't configured yet)
+
+extension Color {
+    enum Fallback {
+        static let brandPrimary = Color(hex: 0x0D9488)
+        static let brandPrimaryLight = Color(hex: 0x5EEAD4)
+        static let brandSecondary = Color(hex: 0x84CC16)
+        static let brandAccent = Color(hex: 0xF59E0B)
+
+        static let bgPrimary = Color(hex: 0xFAFAF5)
+        static let bgSecondary = Color(hex: 0xF0F4F0)
+        static let bgGradientStart = Color(hex: 0xFBF9F0)
+        static let bgGradientEnd = Color(hex: 0xE8F0E8)
+
+        static let textPrimary = Color(hex: 0x1A1A1A)
+        static let textSecondary = Color(hex: 0x6B7280)
+        static let textTertiary = Color(hex: 0x9CA3AF)
+
+        static let statusNormal = Color(hex: 0x22C55E)
+        static let statusWarning = Color(hex: 0xF59E0B)
+        static let statusCritical = Color(hex: 0xEF4444)
+        static let statusInfo = Color(hex: 0x3B82F6)
+
+        static let borderDefault = Color(hex: 0xE5E7EB)
+    }
+}

--- a/AarogyaiOS/Presentation/SharedComponents/Theme/SerenBloomBackground.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Theme/SerenBloomBackground.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SereneBloomBackground: View {
+    var body: some View {
+        LinearGradient(
+            colors: [Color.Fallback.bgGradientStart, Color.Fallback.bgGradientEnd],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+    }
+}
+
+extension View {
+    func sereneBloomBackground() -> some View {
+        background { SereneBloomBackground() }
+    }
+}

--- a/AarogyaiOS/Presentation/SharedComponents/Theme/Typography.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Theme/Typography.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+enum Typography {
+    // Headings — DM Serif Display
+    static let largeTitle = Font.custom("DMSerifDisplay-Regular", size: 34, relativeTo: .largeTitle)
+    static let title = Font.custom("DMSerifDisplay-Regular", size: 28, relativeTo: .title)
+    static let title2 = Font.custom("DMSerifDisplay-Regular", size: 22, relativeTo: .title2)
+
+    // Body — Outfit
+    static let headline = Font.custom("Outfit-SemiBold", size: 17, relativeTo: .headline)
+    static let body = Font.custom("Outfit-Regular", size: 17, relativeTo: .body)
+    static let callout = Font.custom("Outfit-Regular", size: 16, relativeTo: .callout)
+    static let subheadline = Font.custom("Outfit-Regular", size: 15, relativeTo: .subheadline)
+    static let footnote = Font.custom("Outfit-Regular", size: 13, relativeTo: .footnote)
+    static let caption = Font.custom("Outfit-Regular", size: 12, relativeTo: .caption)
+
+    // Data — DM Mono
+    static let data = Font.custom("DMMono-Medium", size: 15, relativeTo: .body)
+    static let dataSmall = Font.custom("DMMono-Regular", size: 13, relativeTo: .footnote)
+}
+
+// MARK: - View Modifier
+
+struct TypeStyle: ViewModifier {
+    let font: Font
+
+    func body(content: Content) -> some View {
+        content.font(font)
+    }
+}
+
+extension View {
+    func typeStyle(_ font: Font) -> some View {
+        modifier(TypeStyle(font: font))
+    }
+}

--- a/AarogyaiOS/Preview Content/PreviewData.swift
+++ b/AarogyaiOS/Preview Content/PreviewData.swift
@@ -1,4 +1,124 @@
 import Foundation
 
-// Mock data for SwiftUI previews will be added as domain models are created.
-enum PreviewData {}
+#if DEBUG
+enum PreviewData {
+    static let user = User(
+        id: "usr_preview_001",
+        firstName: "Priya",
+        lastName: "Sharma",
+        email: "priya@example.com",
+        phone: "+919876543210",
+        address: "Mumbai, Maharashtra",
+        bloodGroup: .oPositive,
+        dateOfBirth: Calendar.current.date(from: DateComponents(year: 1990, month: 5, day: 15)),
+        gender: .female,
+        role: .patient,
+        registrationStatus: .approved,
+        isAadhaarVerified: true,
+        aadhaarRefToken: nil,
+        doctorProfile: nil,
+        labTechProfile: nil,
+        createdAt: .now.addingTimeInterval(-86400 * 30),
+        updatedAt: .now
+    )
+
+    static let report = Report(
+        id: "rpt_preview_001",
+        reportNumber: "RPT-2025-001234",
+        title: "Complete Blood Count",
+        reportType: .bloodTest,
+        status: .extracted,
+        patientId: "usr_preview_001",
+        doctorId: nil,
+        doctorName: "Dr. Anil Gupta",
+        labName: "PathKind Labs",
+        collectedAt: .now.addingTimeInterval(-86400),
+        reportedAt: .now.addingTimeInterval(-43200),
+        uploadedAt: .now.addingTimeInterval(-3600),
+        notes: nil,
+        fileStorageKey: "reports/preview.pdf",
+        fileType: "application/pdf",
+        fileSizeBytes: 1_240_000,
+        checksumSha256: nil,
+        parameters: [
+            ReportParameter(
+                id: "param_001",
+                code: "HGB",
+                name: "Hemoglobin",
+                numericValue: 14.2,
+                textValue: nil,
+                unit: "g/dL",
+                referenceRange: "13.0-17.0",
+                isAbnormal: false
+            ),
+            ReportParameter(
+                id: "param_002",
+                code: "WBC",
+                name: "WBC Count",
+                numericValue: 11500,
+                textValue: nil,
+                unit: "cells/μL",
+                referenceRange: "4000-11000",
+                isAbnormal: true
+            )
+        ],
+        extraction: nil,
+        highlightParameter: "WBC Count: 11500 cells/μL",
+        createdAt: .now.addingTimeInterval(-3600),
+        updatedAt: .now
+    )
+
+    static let accessGrant = AccessGrant(
+        id: "ag_preview_001",
+        patientId: "usr_preview_001",
+        grantedToUserId: "usr_doctor_001",
+        grantedToUserName: "Dr. Anil Gupta",
+        grantedByUserId: "usr_preview_001",
+        grantReason: "Follow-up consultation",
+        scope: AccessScope(allReports: false, reportIds: ["rpt_preview_001"]),
+        status: .active,
+        startsAt: .now.addingTimeInterval(-86400),
+        expiresAt: .now.addingTimeInterval(86400 * 7),
+        revokedAt: nil,
+        createdAt: .now.addingTimeInterval(-86400)
+    )
+
+    static let emergencyContact = EmergencyContact(
+        id: "ec_preview_001",
+        name: "Rahul Sharma",
+        phone: "+919876543211",
+        relationship: .spouse,
+        isPrimary: true,
+        createdAt: .now.addingTimeInterval(-86400 * 60),
+        updatedAt: .now
+    )
+
+    static let reports: [Report] = [
+        report,
+        Report(
+            id: "rpt_preview_002",
+            reportNumber: "RPT-2025-001235",
+            title: "Lipid Profile",
+            reportType: .bloodTest,
+            status: .uploaded,
+            patientId: "usr_preview_001",
+            doctorId: nil,
+            doctorName: nil,
+            labName: "SRL Diagnostics",
+            collectedAt: nil,
+            reportedAt: nil,
+            uploadedAt: .now.addingTimeInterval(-86400 * 3),
+            notes: "Fasting sample",
+            fileStorageKey: nil,
+            fileType: nil,
+            fileSizeBytes: nil,
+            checksumSha256: nil,
+            parameters: [],
+            extraction: nil,
+            highlightParameter: nil,
+            createdAt: .now.addingTimeInterval(-86400 * 3),
+            updatedAt: .now.addingTimeInterval(-86400 * 3)
+        )
+    ]
+}
+#endif

--- a/AarogyaiOSUITests/AarogyaiOSUITests.swift
+++ b/AarogyaiOSUITests/AarogyaiOSUITests.swift
@@ -1,8 +1,13 @@
 import XCTest
 
+@MainActor
 final class AarogyaiOSUITests: XCTestCase {
     func testAppLaunches() throws {
         let app = XCUIApplication()
+        app.launchArguments = ["-ui-testing"]
         app.launch()
+        // App should display the auth screen after failing to fetch user
+        let signInButton = app.buttons["Sign In"]
+        XCTAssertTrue(signInButton.waitForExistence(timeout: 15))
     }
 }

--- a/Configurations/Debug.xcconfig
+++ b/Configurations/Debug.xcconfig
@@ -6,10 +6,6 @@ API_BASE_URL = https:/$()/api.dev.kinvee.in
 // Cognito
 COGNITO_REGION = ap-south-1
 
-// Bundle
-PRODUCT_BUNDLE_IDENTIFIER = com.kinvee.aarogya.dev
-PRODUCT_NAME = Aarogya Dev
-
 // Build
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
 SWIFT_OPTIMIZATION_LEVEL = -Onone

--- a/project.yml
+++ b/project.yml
@@ -41,9 +41,12 @@ targets:
         Debug:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
           SWIFT_OPTIMIZATION_LEVEL: -Onone
-          xcconfig: Configurations/Debug.xcconfig
+          API_BASE_URL: "https://api.dev.kinvee.in"
+          COGNITO_REGION: ap-south-1
         Release:
           SWIFT_OPTIMIZATION_LEVEL: -O
+          API_BASE_URL: "https://api.kinvee.in"
+          COGNITO_REGION: ap-south-1
     dependencies:
       - package: Nuke
     postBuildScripts:


### PR DESCRIPTION
## Summary
- Wire `AarogyaApp` entry point with `DependencyContainer` (manual DI) and SwiftData `ModelContainer`
- Add `AppCoordinator` managing auth-state routing (loading → unauthenticated → pending → rejected → authenticated)
- Add `TabCoordinator` with 4-tab Liquid Glass layout using iOS 26 `Tab` API with `.tabBarMinimizeBehavior`
- Add `Route` enum for typed `NavigationPath` destinations across all features
- Add `ColorTokens`, `Typography`, and `SereneBloomBackground` design system foundations
- Add `PreviewData` with realistic mock domain objects for SwiftUI previews
- Fix xcconfig build setting resolution (moved `API_BASE_URL`/`COGNITO_REGION` to project.yml)

## Test plan
- [x] Project builds successfully
- [x] UI test passes — app launches to Sign In screen
- [ ] CI pipeline passes

Closes #35, closes #36, closes #37, closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)