### PR TITLE
feat(ui): add shared Liquid Glass and content components

### DIFF
--- a/AarogyaiOS/Presentation/SharedComponents/Content/EmptyStateView.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Content/EmptyStateView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    init(
+        icon: String,
+        title: String,
+        subtitle: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.icon = icon
+        self.title = title
+        self.subtitle = subtitle
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(title)
+                .font(Typography.title2)
+
+            Text(subtitle)
+                .font(Typography.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let actionTitle, let action {
+                PrimaryButton(actionTitle, action: action)
+                    .padding(.top, 8)
+                    .frame(maxWidth: 240)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#if DEBUG
+#Preview {
+    EmptyStateView(
+        icon: "doc.text",
+        title: "No reports yet",
+        subtitle: "Upload your first medical report to get started",
+        actionTitle: "Upload Report"
+    ) { }
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Content/ErrorBannerView.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Content/ErrorBannerView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct ErrorBannerView: View {
+    let message: String
+    let retryAction: (() -> Void)?
+    let dismissAction: () -> Void
+
+    init(
+        message: String,
+        retryAction: (() -> Void)? = nil,
+        dismissAction: @escaping () -> Void
+    ) {
+        self.message = message
+        self.retryAction = retryAction
+        self.dismissAction = dismissAction
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.Fallback.statusCritical)
+
+            Text(message)
+                .font(Typography.subheadline)
+                .lineLimit(2)
+
+            Spacer()
+
+            if let retryAction {
+                Button("Retry", action: retryAction)
+                    .font(Typography.subheadline.weight(.semibold))
+            }
+
+            Button(action: dismissAction) {
+                Image(systemName: "xmark")
+                    .font(.caption)
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack {
+        ErrorBannerView(
+            message: "Failed to load reports",
+            retryAction: { },
+            dismissAction: { }
+        )
+        Spacer()
+    }
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Content/LoadingView.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Content/LoadingView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct LoadingView: View {
+    let message: String?
+
+    init(_ message: String? = nil) {
+        self.message = message
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            if let message {
+                Text(message)
+                    .font(Typography.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#if DEBUG
+#Preview {
+    LoadingView("Loading reports...")
+        .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Content/OfflineBannerView.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Content/OfflineBannerView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct OfflineBannerView: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wifi.slash")
+                .font(.caption)
+            Text("You're offline. Showing cached data.")
+                .font(Typography.caption)
+        }
+        .foregroundStyle(.white)
+        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity)
+        .background(Color.Fallback.textSecondary)
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack {
+        OfflineBannerView()
+        Spacer()
+    }
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Content/ReportCard.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Content/ReportCard.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct ReportCard: View {
+    let report: Report
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                reportTypeIcon
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(report.title)
+                        .font(Typography.headline)
+                        .lineLimit(1)
+                    Text(report.reportNumber)
+                        .font(Typography.dataSmall)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                StatusBadge(reportStatus: report.status)
+            }
+
+            if let highlight = report.highlightParameter {
+                Text(highlight)
+                    .font(Typography.data)
+                    .foregroundStyle(Color.Fallback.brandPrimary)
+                    .lineLimit(1)
+            }
+
+            HStack {
+                if let labName = report.labName {
+                    Label(labName, systemImage: "building.2")
+                        .font(Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(report.uploadedAt.formatted(date: .abbreviated, time: .omitted))
+                    .font(Typography.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(16)
+        .background(Color.Fallback.bgSecondary, in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var reportTypeIcon: some View {
+        Image(systemName: iconName)
+            .font(.title3)
+            .foregroundStyle(Color.Fallback.brandPrimary)
+            .frame(width: 40, height: 40)
+            .background(
+                Color.Fallback.brandPrimaryLight.opacity(0.15),
+                in: Circle()
+            )
+    }
+
+    private var iconName: String {
+        switch report.reportType {
+        case .bloodTest: "drop.fill"
+        case .urineTest: "flask.fill"
+        case .radiology: "rays"
+        case .cardiology: "heart.fill"
+        case .other: "doc.text.fill"
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(spacing: 12) {
+        ReportCard(report: PreviewData.report)
+        ReportCard(report: PreviewData.reports[1])
+    }
+    .padding()
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/GlassFAB.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/GlassFAB.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct GlassFAB: View {
+    let icon: String
+    let tintColor: Color
+    let action: () -> Void
+
+    init(
+        icon: String = "plus",
+        tintColor: Color = Color.Fallback.brandPrimary,
+        action: @escaping () -> Void
+    ) {
+        self.icon = icon
+        self.tintColor = tintColor
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.title2)
+                .frame(width: 56, height: 56)
+        }
+        .glassEffect(.regular.tint(tintColor).interactive(), in: .circle)
+    }
+}
+
+#if DEBUG
+#Preview {
+    ZStack(alignment: .bottomTrailing) {
+        Color.clear
+        GlassFAB { }
+            .padding(24)
+    }
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/GlassFilterBar.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/GlassFilterBar.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct GlassFilterBar<T: Hashable>: View {
+    let items: [T]
+    @Binding var selection: T?
+    let allLabel: String
+    let label: (T) -> String
+
+    init(
+        items: [T],
+        selection: Binding<T?>,
+        allLabel: String = "All",
+        label: @escaping (T) -> String
+    ) {
+        self.items = items
+        self._selection = selection
+        self.allLabel = allLabel
+        self.label = label
+    }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            GlassEffectContainer(spacing: 4) {
+                HStack(spacing: 4) {
+                    filterChip(label: allLabel, isSelected: selection == nil) {
+                        withAnimation(.smooth) { selection = nil }
+                    }
+
+                    ForEach(items, id: \.self) { item in
+                        filterChip(
+                            label: label(item),
+                            isSelected: selection == item
+                        ) {
+                            withAnimation(.smooth) { selection = item }
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    private func filterChip(
+        label: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(Typography.caption)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+        }
+        .glassEffect(
+            isSelected
+                ? .regular.tint(Color.Fallback.brandPrimary).interactive()
+                : .regular.interactive(),
+            in: .capsule
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    @Previewable @State var selection: ReportType? = nil
+    GlassFilterBar(
+        items: ReportType.allCases,
+        selection: $selection
+    ) { type in
+        type.rawValue.capitalized
+    }
+    .padding()
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/PrimaryButton.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/PrimaryButton.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct PrimaryButton: View {
+    let title: String
+    let icon: String?
+    let isLoading: Bool
+    let action: () -> Void
+
+    init(
+        _ title: String,
+        icon: String? = nil,
+        isLoading: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.icon = icon
+        self.isLoading = isLoading
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else if let icon {
+                    Image(systemName: icon)
+                }
+                Text(title)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.glassProminent)
+        .disabled(isLoading)
+    }
+}
+
+struct SecondaryButton: View {
+    let title: String
+    let icon: String?
+    let action: () -> Void
+
+    init(
+        _ title: String,
+        icon: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.icon = icon
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if let icon {
+                    Image(systemName: icon)
+                }
+                Text(title)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.glass)
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(spacing: 16) {
+        PrimaryButton("Upload Report", icon: "arrow.up.doc") { }
+        PrimaryButton("Loading...", isLoading: true) { }
+        SecondaryButton("Cancel", icon: "xmark") { }
+    }
+    .padding()
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/SocialLoginButton.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/SocialLoginButton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct SocialLoginButton: View {
+    let provider: SocialProvider
+    let action: () -> Void
+
+    enum SocialProvider {
+        case apple
+        case google
+
+        var label: String {
+            switch self {
+            case .apple: "Continue with Apple"
+            case .google: "Continue with Google"
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .apple: "apple.logo"
+            case .google: "globe"
+            }
+        }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: provider.icon)
+                    .font(.title3)
+                Text(provider.label)
+                    .font(Typography.headline)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.glass)
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(spacing: 12) {
+        SocialLoginButton(provider: .apple) { }
+        SocialLoginButton(provider: .google) { }
+    }
+    .padding()
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/StatusBadge.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/StatusBadge.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct StatusBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .glassEffect(.regular.tint(color), in: .capsule)
+    }
+}
+
+extension StatusBadge {
+    init(reportStatus: ReportStatus) {
+        self.text = reportStatus.rawValue.capitalized
+        self.color = switch reportStatus {
+        case .clean, .validated, .published:
+            Color.Fallback.statusNormal
+        case .infected:
+            Color.Fallback.statusCritical
+        case .processing, .extracting:
+            Color.Fallback.statusWarning
+        case .draft, .uploaded, .archived, .extracted, .extractionFailed:
+            Color.Fallback.statusInfo
+        }
+    }
+
+    init(accessGrantStatus: AccessGrantStatus) {
+        self.text = accessGrantStatus.rawValue.capitalized
+        self.color = switch accessGrantStatus {
+        case .active:
+            Color.Fallback.statusNormal
+        case .expired, .revoked:
+            Color.Fallback.statusCritical
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    HStack(spacing: 8) {
+        StatusBadge(reportStatus: .clean)
+        StatusBadge(reportStatus: .infected)
+        StatusBadge(reportStatus: .processing)
+        StatusBadge(accessGrantStatus: .active)
+    }
+    .padding()
+    .sereneBloomBackground()
+}
+#endif

--- a/AarogyaiOS/Presentation/SharedComponents/Theme/SerenBloomBackground.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Theme/SerenBloomBackground.swift
@@ -1,13 +1,23 @@
 import SwiftUI
 
 struct SereneBloomBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         LinearGradient(
-            colors: [Color.Fallback.bgGradientStart, Color.Fallback.bgGradientEnd],
+            colors: gradientColors,
             startPoint: .topLeading,
             endPoint: .bottomTrailing
         )
         .ignoresSafeArea()
+    }
+
+    private var gradientColors: [Color] {
+        if colorScheme == .dark {
+            [Color(hex: 0x0C1917), Color(hex: 0x132624)]
+        } else {
+            [Color(hex: 0xFBF9F0), Color(hex: 0xE8F0E8)]
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add Liquid Glass navigation-layer components: `GlassFilterBar` (scrolling filter chips), `GlassFAB` (floating action button), `StatusBadge` (tinted status labels), `PrimaryButton`/`SecondaryButton`, `SocialLoginButton`
- Add content-layer components: `ReportCard` (report summary card), `EmptyStateView`, `ErrorBannerView`, `LoadingView`, `OfflineBannerView`
- Update `SereneBloomBackground` with proper light/dark mode gradient colors
- All components include SwiftUI `#Preview` blocks

## Test plan
- [x] Project builds successfully
- [x] All tests pass
- [ ] CI pipeline passes

Closes #39, closes #40, closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)