### PR TITLE
feat(screens): implement access, emergency, and settings screens

### DIFF
--- a/AarogyaiOS/App/AarogyaApp.swift
+++ b/AarogyaiOS/App/AarogyaApp.swift
@@ -53,7 +53,10 @@ struct RootView: View {
                     }
                 )
             case .authenticated:
-                TabCoordinator()
+                TabCoordinator(
+                    container: container,
+                    onSignOut: { await coordinator.handleLogout() }
+                )
             }
         }
         .environment(coordinator)

--- a/AarogyaiOS/Domain/Models/NotificationPreferences.swift
+++ b/AarogyaiOS/Domain/Models/NotificationPreferences.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct NotificationPreferences: Sendable {
+struct NotificationPreferences: Sendable, Equatable {
     var reportUploaded: ChannelPreferences
     var accessGranted: ChannelPreferences
     var emergencyAccess: ChannelPreferences
 }
 
-struct ChannelPreferences: Sendable {
+struct ChannelPreferences: Sendable, Equatable {
     var push: Bool
     var email: Bool
     var sms: Bool

--- a/AarogyaiOS/Presentation/Access/AccessGrantsView.swift
+++ b/AarogyaiOS/Presentation/Access/AccessGrantsView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct AccessGrantsView: View {
+    @State var viewModel: AccessGrantsViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && viewModel.grantedGrants.isEmpty {
+                LoadingView("Loading access grants...")
+            } else if viewModel.grantedGrants.isEmpty && viewModel.receivedGrants.isEmpty {
+                EmptyStateView(
+                    icon: "person.2",
+                    title: "No access grants",
+                    subtitle: "Grant doctors access to your medical reports",
+                    actionTitle: "Grant Access"
+                ) {
+                    viewModel.showCreateGrant = true
+                }
+            } else {
+                grantsList
+            }
+        }
+        .navigationTitle("Access Grants")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    viewModel.showCreateGrant = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .refreshable { await viewModel.loadGrants() }
+        .task { await viewModel.loadGrants() }
+        .sheet(isPresented: $viewModel.showCreateGrant) {
+            Task { await viewModel.onGrantCreated() }
+        } content: {
+            CreateAccessGrantView(
+                createUseCase: viewModel.createGrantUseCase
+            )
+        }
+    }
+
+    private var grantsList: some View {
+        List {
+            if !viewModel.grantedGrants.isEmpty {
+                Section("Granted by You") {
+                    ForEach(viewModel.grantedGrants) { grant in
+                        AccessGrantRow(grant: grant) {
+                            Task { await viewModel.revokeGrant(grant) }
+                        }
+                    }
+                }
+            }
+
+            if !viewModel.receivedGrants.isEmpty {
+                Section("Granted to You") {
+                    ForEach(viewModel.receivedGrants) { grant in
+                        AccessGrantRow(grant: grant, revokeAction: nil)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct AccessGrantRow: View {
+    let grant: AccessGrant
+    let revokeAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(grant.grantedToUserName ?? "Unknown User")
+                    .font(Typography.headline)
+                Spacer()
+                StatusBadge(accessGrantStatus: grant.status)
+            }
+
+            if let reason = grant.grantReason {
+                Text(reason)
+                    .font(Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Text(grant.scope.allReports ? "All Reports" : "\(grant.scope.reportIds.count) reports")
+                    .font(Typography.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if let expires = grant.expiresAt {
+                    Text("Expires \(expires.formatted(date: .abbreviated, time: .omitted))")
+                        .font(Typography.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            if let revokeAction, grant.status == .active {
+                Button("Revoke Access", role: .destructive, action: revokeAction)
+                    .font(Typography.caption)
+            }
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Access/AccessGrantsViewModel.swift
+++ b/AarogyaiOS/Presentation/Access/AccessGrantsViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class AccessGrantsViewModel {
+    var grantedGrants: [AccessGrant] = []
+    var receivedGrants: [AccessGrant] = []
+    var isLoading = false
+    var error: String?
+    var showCreateGrant = false
+
+    private let fetchGrantsUseCase: FetchAccessGrantsUseCase
+    let createGrantUseCase: CreateAccessGrantUseCase
+    private let revokeGrantUseCase: RevokeAccessGrantUseCase
+
+    init(
+        fetchGrantsUseCase: FetchAccessGrantsUseCase,
+        createGrantUseCase: CreateAccessGrantUseCase,
+        revokeGrantUseCase: RevokeAccessGrantUseCase
+    ) {
+        self.fetchGrantsUseCase = fetchGrantsUseCase
+        self.createGrantUseCase = createGrantUseCase
+        self.revokeGrantUseCase = revokeGrantUseCase
+    }
+
+    func loadGrants() async {
+        isLoading = true
+        error = nil
+
+        do {
+            async let granted = fetchGrantsUseCase.executeGiven()
+            async let received = fetchGrantsUseCase.executeReceived()
+            let (grantedResult, receivedResult) = try await (granted, received)
+            grantedGrants = grantedResult
+            receivedGrants = receivedResult
+        } catch {
+            self.error = "Failed to load access grants"
+            Logger.data.error("Load grants failed: \(error)")
+        }
+
+        isLoading = false
+    }
+
+    func revokeGrant(_ grant: AccessGrant) async {
+        do {
+            try await revokeGrantUseCase.execute(grantId: grant.id)
+            grantedGrants.removeAll { $0.id == grant.id }
+        } catch {
+            self.error = "Failed to revoke access"
+            Logger.data.error("Revoke grant failed: \(error)")
+        }
+    }
+
+    func onGrantCreated() async {
+        await loadGrants()
+    }
+}

--- a/AarogyaiOS/Presentation/Access/CreateAccessGrantView.swift
+++ b/AarogyaiOS/Presentation/Access/CreateAccessGrantView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct CreateAccessGrantView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var grantedToUserId = ""
+    @State private var grantReason = ""
+    @State private var allReports = true
+    @State private var expiresIn: ExpiryOption = .oneWeek
+    @State private var isSaving = false
+    @State private var error: String?
+
+    let createUseCase: CreateAccessGrantUseCase
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Grant To") {
+                    TextField("User ID or Phone", text: $grantedToUserId)
+                        .textContentType(.telephoneNumber)
+                        .autocorrectionDisabled()
+                }
+
+                Section("Scope") {
+                    Toggle("All Reports", isOn: $allReports)
+                }
+
+                Section("Duration") {
+                    Picker("Expires In", selection: $expiresIn) {
+                        ForEach(ExpiryOption.allCases) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                }
+
+                Section("Reason (Optional)") {
+                    TextField("e.g. Follow-up consultation", text: $grantReason, axis: .vertical)
+                        .lineLimit(2...4)
+                }
+
+                if let error {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(Color.Fallback.statusCritical)
+                            .font(Typography.caption)
+                    }
+                }
+            }
+            .navigationTitle("Grant Access")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Grant") {
+                        Task { await createGrant() }
+                    }
+                    .disabled(grantedToUserId.trimmingCharacters(in: .whitespaces).isEmpty || isSaving)
+                }
+            }
+        }
+    }
+
+    private func createGrant() async {
+        isSaving = true
+        error = nil
+
+        let input = CreateAccessGrantInput(
+            grantedToUserId: grantedToUserId.trimmingCharacters(in: .whitespaces),
+            scope: AccessScope(allReports: allReports, reportIds: []),
+            grantReason: grantReason.isEmpty ? nil : grantReason,
+            expiresAt: expiresIn.date
+        )
+
+        do {
+            _ = try await createUseCase.execute(request: input)
+            dismiss()
+        } catch {
+            self.error = "Failed to create access grant"
+        }
+
+        isSaving = false
+    }
+}
+
+private enum ExpiryOption: String, CaseIterable, Identifiable {
+    case oneDay
+    case oneWeek
+    case oneMonth
+    case threeMonths
+    case noExpiry
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .oneDay: "1 Day"
+        case .oneWeek: "1 Week"
+        case .oneMonth: "1 Month"
+        case .threeMonths: "3 Months"
+        case .noExpiry: "No Expiry"
+        }
+    }
+
+    var date: Date? {
+        let calendar = Calendar.current
+        switch self {
+        case .oneDay: return calendar.date(byAdding: .day, value: 1, to: .now)
+        case .oneWeek: return calendar.date(byAdding: .weekOfYear, value: 1, to: .now)
+        case .oneMonth: return calendar.date(byAdding: .month, value: 1, to: .now)
+        case .threeMonths: return calendar.date(byAdding: .month, value: 3, to: .now)
+        case .noExpiry: return nil
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Emergency/EmergencyContactFormView.swift
+++ b/AarogyaiOS/Presentation/Emergency/EmergencyContactFormView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct EmergencyContactFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var phone: String
+    @State private var relationship: Relationship
+    @State private var isPrimary: Bool
+    @State private var isSaving = false
+    @State private var error: String?
+
+    private let existingContact: EmergencyContact?
+    private let manageUseCase: ManageEmergencyContactUseCase
+
+    init(contact: EmergencyContact?, manageUseCase: ManageEmergencyContactUseCase) {
+        self.existingContact = contact
+        self.manageUseCase = manageUseCase
+        _name = State(initialValue: contact?.name ?? "")
+        _phone = State(initialValue: contact?.phone ?? "")
+        _relationship = State(initialValue: contact?.relationship ?? .spouse)
+        _isPrimary = State(initialValue: contact?.isPrimary ?? false)
+    }
+
+    private var isEditing: Bool { existingContact != nil }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Contact Details") {
+                    TextField("Full Name", text: $name)
+                        .textContentType(.name)
+
+                    TextField("Phone Number", text: $phone)
+                        .textContentType(.telephoneNumber)
+                        .keyboardType(.phonePad)
+                }
+
+                Section("Relationship") {
+                    Picker("Relationship", selection: $relationship) {
+                        ForEach(Relationship.allCases, id: \.self) { rel in
+                            Text(rel.rawValue.capitalized).tag(rel)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Section {
+                    Toggle("Primary Contact", isOn: $isPrimary)
+                } footer: {
+                    Text("Primary contacts are notified first in emergencies")
+                }
+
+                if let error {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(Color.Fallback.statusCritical)
+                            .font(Typography.caption)
+                    }
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Contact" : "Add Contact")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .disabled(!isValid || isSaving)
+                }
+            }
+        }
+    }
+
+    private var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+            && !phone.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func save() async {
+        isSaving = true
+        error = nil
+
+        let input = EmergencyContactInput(
+            name: name.trimmingCharacters(in: .whitespaces),
+            phone: phone.trimmingCharacters(in: .whitespaces),
+            relationship: relationship,
+            isPrimary: isPrimary
+        )
+
+        do {
+            if let existing = existingContact {
+                _ = try await manageUseCase.update(id: existing.id, request: input)
+            } else {
+                _ = try await manageUseCase.create(request: input)
+            }
+            dismiss()
+        } catch {
+            self.error = isEditing ? "Failed to update contact" : "Failed to add contact"
+        }
+
+        isSaving = false
+    }
+}

--- a/AarogyaiOS/Presentation/Emergency/EmergencyContactsView.swift
+++ b/AarogyaiOS/Presentation/Emergency/EmergencyContactsView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct EmergencyContactsView: View {
+    @State var viewModel: EmergencyContactsViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && viewModel.contacts.isEmpty {
+                LoadingView("Loading contacts...")
+            } else if viewModel.contacts.isEmpty {
+                EmptyStateView(
+                    icon: "phone.fill",
+                    title: "No emergency contacts",
+                    subtitle: "Add trusted contacts who can access your records in emergencies",
+                    actionTitle: "Add Contact"
+                ) {
+                    viewModel.addContact()
+                }
+            } else {
+                contactsList
+            }
+        }
+        .navigationTitle("Emergency Contacts")
+        .toolbar {
+            if viewModel.canAddMore {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        viewModel.addContact()
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+        .refreshable { await viewModel.loadContacts() }
+        .task { await viewModel.loadContacts() }
+        .sheet(isPresented: $viewModel.showContactForm) {
+            Task { await viewModel.onContactSaved() }
+        } content: {
+            EmergencyContactFormView(
+                contact: viewModel.editingContact,
+                manageUseCase: viewModel.manageUseCase
+            )
+        }
+    }
+
+    private var contactsList: some View {
+        List {
+            ForEach(viewModel.contacts) { contact in
+                EmergencyContactRow(contact: contact) {
+                    viewModel.editContact(contact)
+                }
+                .swipeActions(edge: .trailing) {
+                    Button("Delete", role: .destructive) {
+                        Task { await viewModel.deleteContact(contact) }
+                    }
+                }
+            }
+
+            Section {
+                Text("\(viewModel.contacts.count)/\(Constants.EmergencyContacts.maxCount) contacts")
+                    .font(Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct EmergencyContactRow: View {
+    let contact: EmergencyContact
+    let onEdit: () -> Void
+
+    var body: some View {
+        Button(action: onEdit) {
+            HStack(spacing: 12) {
+                Image(systemName: "person.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(
+                        contact.isPrimary
+                            ? Color.Fallback.brandPrimary
+                            : .secondary
+                    )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(contact.name)
+                            .font(Typography.headline)
+                        if contact.isPrimary {
+                            Text("Primary")
+                                .font(Typography.caption)
+                                .foregroundStyle(Color.Fallback.brandPrimary)
+                        }
+                    }
+                    Text(contact.relationship.rawValue.capitalized)
+                        .font(Typography.caption)
+                        .foregroundStyle(.secondary)
+                    Text(contact.phone)
+                        .font(Typography.dataSmall)
+                        .foregroundStyle(.tertiary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/AarogyaiOS/Presentation/Emergency/EmergencyContactsViewModel.swift
+++ b/AarogyaiOS/Presentation/Emergency/EmergencyContactsViewModel.swift
@@ -1,0 +1,65 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class EmergencyContactsViewModel {
+    var contacts: [EmergencyContact] = []
+    var isLoading = false
+    var error: String?
+    var editingContact: EmergencyContact?
+    var showContactForm = false
+
+    let fetchUseCase: FetchEmergencyContactsUseCase
+    let manageUseCase: ManageEmergencyContactUseCase
+
+    init(
+        fetchUseCase: FetchEmergencyContactsUseCase,
+        manageUseCase: ManageEmergencyContactUseCase
+    ) {
+        self.fetchUseCase = fetchUseCase
+        self.manageUseCase = manageUseCase
+    }
+
+    var canAddMore: Bool {
+        contacts.count < Constants.EmergencyContacts.maxCount
+    }
+
+    func loadContacts() async {
+        isLoading = true
+        error = nil
+
+        do {
+            contacts = try await fetchUseCase.execute()
+        } catch {
+            self.error = "Failed to load contacts"
+            Logger.data.error("Load contacts failed: \(error)")
+        }
+
+        isLoading = false
+    }
+
+    func deleteContact(_ contact: EmergencyContact) async {
+        do {
+            try await manageUseCase.delete(id: contact.id)
+            contacts.removeAll { $0.id == contact.id }
+        } catch {
+            self.error = "Failed to delete contact"
+            Logger.data.error("Delete contact failed: \(error)")
+        }
+    }
+
+    func addContact() {
+        editingContact = nil
+        showContactForm = true
+    }
+
+    func editContact(_ contact: EmergencyContact) {
+        editingContact = contact
+        showContactForm = true
+    }
+
+    func onContactSaved() async {
+        await loadContacts()
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -8,44 +8,55 @@ enum AppTab: String, CaseIterable, Sendable {
 }
 
 struct TabCoordinator: View {
+    let container: DependencyContainer
+    let onSignOut: () async -> Void
+
     @State private var selectedTab: AppTab = .reports
 
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Reports", systemImage: "doc.text", value: .reports) {
                 NavigationStack {
-                    PlaceholderView(title: "Reports")
+                    ReportsListView(viewModel: ReportsListViewModel(
+                        fetchReportsUseCase: container.fetchReportsUseCase
+                    ))
                 }
             }
 
             Tab("Access", systemImage: "person.2", value: .access) {
                 NavigationStack {
-                    PlaceholderView(title: "Access Grants")
+                    AccessGrantsView(viewModel: AccessGrantsViewModel(
+                        fetchGrantsUseCase: container.fetchAccessGrantsUseCase,
+                        createGrantUseCase: container.createAccessGrantUseCase,
+                        revokeGrantUseCase: container.revokeAccessGrantUseCase
+                    ))
                 }
             }
 
             Tab("Emergency", systemImage: "phone.fill", value: .emergency) {
                 NavigationStack {
-                    PlaceholderView(title: "Emergency Contacts")
+                    EmergencyContactsView(viewModel: EmergencyContactsViewModel(
+                        fetchUseCase: container.fetchEmergencyContactsUseCase,
+                        manageUseCase: container.manageEmergencyContactUseCase
+                    ))
                 }
             }
 
             Tab("Settings", systemImage: "gearshape", value: .settings) {
                 NavigationStack {
-                    PlaceholderView(title: "Settings")
+                    SettingsView(viewModel: SettingsViewModel(
+                        getCurrentUserUseCase: container.getCurrentUserUseCase,
+                        updateProfileUseCase: container.updateProfileUseCase,
+                        manageConsentsUseCase: container.manageConsentsUseCase,
+                        manageNotificationsUseCase: container.manageNotificationsUseCase,
+                        logoutUseCase: container.logoutUseCase,
+                        exportDataUseCase: container.exportDataUseCase,
+                        requestAccountDeletionUseCase: container.requestAccountDeletionUseCase,
+                        onSignOut: onSignOut
+                    ))
                 }
             }
         }
         .tabBarMinimizeBehavior(.onScrollDown)
-    }
-}
-
-private struct PlaceholderView: View {
-    let title: String
-
-    var body: some View {
-        Text(title)
-            .font(.title)
-            .navigationTitle(title)
     }
 }

--- a/AarogyaiOS/Presentation/Settings/ConsentsView.swift
+++ b/AarogyaiOS/Presentation/Settings/ConsentsView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ConsentsView: View {
+    @State var viewModel: ConsentsViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                LoadingView("Loading consents...")
+            } else {
+                consentsList
+            }
+        }
+        .navigationTitle("Privacy & Consents")
+        .task { await viewModel.loadConsents() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
+    }
+
+    private var consentsList: some View {
+        List {
+            Section {
+                Text("Manage your data processing consents as per DPDPA regulations.")
+                    .font(Typography.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(ConsentPurpose.allCases, id: \.self) { purpose in
+                Section {
+                    Toggle(isOn: Binding(
+                        get: { viewModel.isGranted(purpose) },
+                        set: { newValue in
+                            Task { await viewModel.toggleConsent(purpose: purpose, isGranted: newValue) }
+                        }
+                    )) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(purpose.displayName)
+                                .font(Typography.headline)
+                            Text(purpose.description)
+                                .font(Typography.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .disabled(purpose.isRequired)
+
+                    if purpose.isRequired {
+                        Text("Required for core functionality")
+                            .font(Typography.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/ConsentsViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/ConsentsViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class ConsentsViewModel {
+    var consents: [ConsentRecord] = []
+    var isLoading = false
+    var error: String?
+
+    private let manageConsentsUseCase: ManageConsentsUseCase
+
+    init(manageConsentsUseCase: ManageConsentsUseCase) {
+        self.manageConsentsUseCase = manageConsentsUseCase
+    }
+
+    func isGranted(_ purpose: ConsentPurpose) -> Bool {
+        consents.first { $0.purpose == purpose }?.isGranted ?? purpose.isRequired
+    }
+
+    func loadConsents() async {
+        isLoading = true
+        // Initialize with defaults — the upsert call returns current state
+        for purpose in ConsentPurpose.allCases where consents.first(where: { $0.purpose == purpose }) == nil {
+            consents.append(ConsentRecord(
+                purpose: purpose,
+                isGranted: purpose.isRequired,
+                source: "default",
+                occurredAt: .now
+            ))
+        }
+        isLoading = false
+    }
+
+    func toggleConsent(purpose: ConsentPurpose, isGranted: Bool) async {
+        guard !purpose.isRequired else { return }
+
+        do {
+            let updated = try await manageConsentsUseCase.upsert(purpose: purpose, isGranted: isGranted)
+            if let index = consents.firstIndex(where: { $0.purpose == purpose }) {
+                consents[index] = updated
+            } else {
+                consents.append(updated)
+            }
+        } catch {
+            self.error = "Failed to update consent"
+            Logger.data.error("Consent update failed: \(error)")
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/NotificationPreferencesView.swift
+++ b/AarogyaiOS/Presentation/Settings/NotificationPreferencesView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct NotificationPreferencesView: View {
+    @State var viewModel: NotificationPreferencesViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                LoadingView("Loading preferences...")
+            } else {
+                preferencesList
+            }
+        }
+        .navigationTitle("Notifications")
+        .task { await viewModel.loadPreferences() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
+    }
+
+    private var preferencesList: some View {
+        List {
+            channelSection(
+                title: "Report Uploaded",
+                subtitle: "When a new report is uploaded to your account",
+                preferences: $viewModel.reportUploaded
+            )
+
+            channelSection(
+                title: "Access Granted",
+                subtitle: "When someone grants or revokes access to records",
+                preferences: $viewModel.accessGranted
+            )
+
+            channelSection(
+                title: "Emergency Access",
+                subtitle: "When emergency access is requested or used",
+                preferences: $viewModel.emergencyAccess
+            )
+
+            Section {
+                Button("Save Preferences") {
+                    Task { await viewModel.savePreferences() }
+                }
+                .disabled(!viewModel.hasChanges || viewModel.isSaving)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private func channelSection(
+        title: String,
+        subtitle: String,
+        preferences: Binding<ChannelPreferences>
+    ) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(Typography.headline)
+                Text(subtitle)
+                    .font(Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Toggle("Push Notifications", isOn: preferences.push)
+            Toggle("Email", isOn: preferences.email)
+            Toggle("SMS", isOn: preferences.sms)
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/NotificationPreferencesViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/NotificationPreferencesViewModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class NotificationPreferencesViewModel {
+    var reportUploaded = ChannelPreferences(push: true, email: true, sms: false)
+    var accessGranted = ChannelPreferences(push: true, email: true, sms: false)
+    var emergencyAccess = ChannelPreferences(push: true, email: true, sms: true)
+
+    var isLoading = false
+    var isSaving = false
+    var error: String?
+
+    private var originalPreferences: NotificationPreferences?
+    private let manageNotificationsUseCase: ManageNotificationsUseCase
+
+    init(manageNotificationsUseCase: ManageNotificationsUseCase) {
+        self.manageNotificationsUseCase = manageNotificationsUseCase
+    }
+
+    var hasChanges: Bool {
+        guard let original = originalPreferences else { return false }
+        let current = currentPreferences
+        return current.reportUploaded != original.reportUploaded
+            || current.accessGranted != original.accessGranted
+            || current.emergencyAccess != original.emergencyAccess
+    }
+
+    func loadPreferences() async {
+        isLoading = true
+        do {
+            let prefs = try await manageNotificationsUseCase.getPreferences()
+            reportUploaded = prefs.reportUploaded
+            accessGranted = prefs.accessGranted
+            emergencyAccess = prefs.emergencyAccess
+            originalPreferences = prefs
+        } catch {
+            self.error = "Failed to load notification preferences"
+            Logger.data.error("Load preferences failed: \(error)")
+        }
+        isLoading = false
+    }
+
+    func savePreferences() async {
+        isSaving = true
+        error = nil
+        do {
+            let updated = try await manageNotificationsUseCase.updatePreferences(currentPreferences)
+            reportUploaded = updated.reportUploaded
+            accessGranted = updated.accessGranted
+            emergencyAccess = updated.emergencyAccess
+            originalPreferences = updated
+        } catch {
+            self.error = "Failed to save preferences"
+            Logger.data.error("Save preferences failed: \(error)")
+        }
+        isSaving = false
+    }
+
+    private var currentPreferences: NotificationPreferences {
+        NotificationPreferences(
+            reportUploaded: reportUploaded,
+            accessGranted: accessGranted,
+            emergencyAccess: emergencyAccess
+        )
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/ProfileEditView.swift
+++ b/AarogyaiOS/Presentation/Settings/ProfileEditView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct ProfileEditView: View {
+    @State var viewModel: ProfileEditViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                LoadingView("Loading profile...")
+            } else {
+                profileForm
+            }
+        }
+        .navigationTitle("Profile")
+        .task { await viewModel.loadProfile() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
+    }
+
+    private var profileForm: some View {
+        Form {
+            Section("Personal Information") {
+                TextField("First Name", text: $viewModel.firstName)
+                    .textContentType(.givenName)
+                TextField("Last Name", text: $viewModel.lastName)
+                    .textContentType(.familyName)
+                TextField("Email", text: $viewModel.email)
+                    .textContentType(.emailAddress)
+                    .keyboardType(.emailAddress)
+                    .disabled(true)
+                TextField("Phone", text: $viewModel.phone)
+                    .textContentType(.telephoneNumber)
+                    .keyboardType(.phonePad)
+                    .disabled(true)
+            }
+
+            Section("Health Information") {
+                Picker("Blood Group", selection: $viewModel.bloodGroup) {
+                    Text("Not Set").tag(BloodGroup?.none)
+                    ForEach(BloodGroup.allCases, id: \.self) { group in
+                        Text(group.rawValue).tag(BloodGroup?.some(group))
+                    }
+                }
+
+                DatePicker(
+                    "Date of Birth",
+                    selection: Binding(
+                        get: { viewModel.dateOfBirth ?? .now },
+                        set: { viewModel.dateOfBirth = $0 }
+                    ),
+                    displayedComponents: .date
+                )
+
+                Picker("Gender", selection: $viewModel.gender) {
+                    Text("Not Set").tag(Gender?.none)
+                    ForEach(Gender.allCases, id: \.self) { gender in
+                        Text(gender.rawValue.capitalized).tag(Gender?.some(gender))
+                    }
+                }
+            }
+
+            Section("Address") {
+                TextField("Address", text: Binding(
+                    get: { viewModel.address ?? "" },
+                    set: { viewModel.address = $0.isEmpty ? nil : $0 }
+                ), axis: .vertical)
+                    .lineLimit(2...4)
+            }
+
+            Section {
+                Button("Save Changes") {
+                    Task { await viewModel.saveProfile() }
+                }
+                .disabled(!viewModel.hasChanges || viewModel.isSaving)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/ProfileEditViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/ProfileEditViewModel.swift
@@ -1,0 +1,89 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class ProfileEditViewModel {
+    var firstName = ""
+    var lastName = ""
+    var email = ""
+    var phone = ""
+    var bloodGroup: BloodGroup?
+    var dateOfBirth: Date?
+    var gender: Gender?
+    var address: String?
+
+    var isLoading = false
+    var isSaving = false
+    var error: String?
+
+    private var originalUser: User?
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+    private let updateProfileUseCase: UpdateProfileUseCase
+
+    init(
+        getCurrentUserUseCase: GetCurrentUserUseCase,
+        updateProfileUseCase: UpdateProfileUseCase
+    ) {
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+        self.updateProfileUseCase = updateProfileUseCase
+    }
+
+    var hasChanges: Bool {
+        guard let user = originalUser else { return false }
+        return firstName != user.firstName
+            || lastName != user.lastName
+            || bloodGroup != user.bloodGroup
+            || dateOfBirth != user.dateOfBirth
+            || gender != user.gender
+            || address != user.address
+    }
+
+    func loadProfile() async {
+        isLoading = true
+        do {
+            let user = try await getCurrentUserUseCase.execute()
+            populateFields(from: user)
+            originalUser = user
+        } catch {
+            self.error = "Failed to load profile"
+            Logger.data.error("Load profile failed: \(error)")
+        }
+        isLoading = false
+    }
+
+    func saveProfile() async {
+        guard var user = originalUser else { return }
+        isSaving = true
+        error = nil
+
+        user.firstName = firstName
+        user.lastName = lastName
+        user.bloodGroup = bloodGroup
+        user.dateOfBirth = dateOfBirth
+        user.gender = gender
+        user.address = address
+
+        do {
+            let updated = try await updateProfileUseCase.execute(user: user)
+            populateFields(from: updated)
+            originalUser = updated
+        } catch {
+            self.error = "Failed to save profile"
+            Logger.data.error("Save profile failed: \(error)")
+        }
+
+        isSaving = false
+    }
+
+    private func populateFields(from user: User) {
+        firstName = user.firstName
+        lastName = user.lastName
+        email = user.email
+        phone = user.phone
+        bloodGroup = user.bloodGroup
+        dateOfBirth = user.dateOfBirth
+        gender = user.gender
+        address = user.address
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/SettingsView.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State var viewModel: SettingsViewModel
+
+    var body: some View {
+        List {
+            Section("Account") {
+                NavigationLink(value: SettingsRoute.profile) {
+                    Label("Profile", systemImage: "person")
+                }
+                NavigationLink(value: SettingsRoute.consents) {
+                    Label("Privacy & Consents", systemImage: "hand.raised")
+                }
+                NavigationLink(value: SettingsRoute.notifications) {
+                    Label("Notifications", systemImage: "bell")
+                }
+            }
+
+            Section("Data") {
+                Button {
+                    Task { await viewModel.exportData() }
+                } label: {
+                    Label("Export My Data", systemImage: "square.and.arrow.up")
+                }
+                .disabled(viewModel.isExporting)
+            }
+
+            Section("Danger Zone") {
+                Button(role: .destructive) {
+                    viewModel.showDeleteConfirmation = true
+                } label: {
+                    Label("Delete Account", systemImage: "trash")
+                }
+            }
+
+            Section {
+                Button("Sign Out", role: .destructive) {
+                    Task { await viewModel.signOut() }
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Text("Aarogya v1.0")
+                        .font(Typography.caption)
+                        .foregroundStyle(.tertiary)
+                    Spacer()
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .navigationDestination(for: SettingsRoute.self) { route in
+            switch route {
+            case .profile:
+                ProfileEditView(viewModel: ProfileEditViewModel(
+                    getCurrentUserUseCase: viewModel.getCurrentUserUseCase,
+                    updateProfileUseCase: viewModel.updateProfileUseCase
+                ))
+            case .consents:
+                ConsentsView(viewModel: ConsentsViewModel(
+                    manageConsentsUseCase: viewModel.manageConsentsUseCase
+                ))
+            case .notifications:
+                NotificationPreferencesView(viewModel: NotificationPreferencesViewModel(
+                    manageNotificationsUseCase: viewModel.manageNotificationsUseCase
+                ))
+            }
+        }
+        .alert("Delete Account", isPresented: $viewModel.showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.requestAccountDeletion() }
+            }
+        } message: {
+            Text("This action is irreversible. All your data will be permanently deleted.")
+        }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.error = nil }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
+    }
+}
+
+enum SettingsRoute: Hashable {
+    case profile
+    case consents
+    case notifications
+}

--- a/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class SettingsViewModel {
+    var isExporting = false
+    var error: String?
+    var showDeleteConfirmation = false
+
+    let getCurrentUserUseCase: GetCurrentUserUseCase
+    let updateProfileUseCase: UpdateProfileUseCase
+    let manageConsentsUseCase: ManageConsentsUseCase
+    let manageNotificationsUseCase: ManageNotificationsUseCase
+    private let logoutUseCase: LogoutUseCase
+    private let exportDataUseCase: ExportDataUseCase
+    private let requestAccountDeletionUseCase: RequestAccountDeletionUseCase
+    private let onSignOut: () async -> Void
+
+    init(
+        getCurrentUserUseCase: GetCurrentUserUseCase,
+        updateProfileUseCase: UpdateProfileUseCase,
+        manageConsentsUseCase: ManageConsentsUseCase,
+        manageNotificationsUseCase: ManageNotificationsUseCase,
+        logoutUseCase: LogoutUseCase,
+        exportDataUseCase: ExportDataUseCase,
+        requestAccountDeletionUseCase: RequestAccountDeletionUseCase,
+        onSignOut: @escaping () async -> Void
+    ) {
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+        self.updateProfileUseCase = updateProfileUseCase
+        self.manageConsentsUseCase = manageConsentsUseCase
+        self.manageNotificationsUseCase = manageNotificationsUseCase
+        self.logoutUseCase = logoutUseCase
+        self.exportDataUseCase = exportDataUseCase
+        self.requestAccountDeletionUseCase = requestAccountDeletionUseCase
+        self.onSignOut = onSignOut
+    }
+
+    func signOut() async {
+        do {
+            try await logoutUseCase.execute()
+        } catch {
+            Logger.auth.error("Logout error: \(error)")
+        }
+        await onSignOut()
+    }
+
+    func exportData() async {
+        isExporting = true
+        do {
+            try await exportDataUseCase.execute()
+        } catch {
+            self.error = "Failed to export data"
+            Logger.data.error("Export data failed: \(error)")
+        }
+        isExporting = false
+    }
+
+    func requestAccountDeletion() async {
+        do {
+            try await requestAccountDeletionUseCase.execute()
+            await signOut()
+        } catch {
+            self.error = "Failed to request account deletion"
+            Logger.data.error("Account deletion failed: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Access Grants** (#48, #49): List view with granted/received sections, create grant form, revoke functionality
- **Emergency Contacts** (#50, #51): List view with swipe-to-delete, add/edit contact form with relationship picker
- **Settings** (#52-#56): Settings hub with profile editing, DPDPA consent management, notification preferences, data export, account deletion
- **TabCoordinator**: Wired all four tabs to real views with DependencyContainer injection
- **NotificationPreferences**: Added `Equatable` conformance for change detection

Closes #48, closes #49, closes #50, closes #51, closes #52, closes #53, closes #54, closes #55, closes #56

## Test plan
- [ ] Build succeeds on iOS 26 simulator
- [ ] Existing UI tests pass
- [ ] Access grants tab renders empty state, list, and create form
- [ ] Emergency contacts tab renders list with add/edit/delete
- [ ] Settings tab navigates to profile, consents, and notification preferences
- [ ] Sign out from settings triggers auth state change

🤖 Generated with [Claude Code](https://claude.com/claude-code)