### PR TITLE
feat(navigation): implement deep link and universal link handling

### DIFF
--- a/AarogyaiOS/App/AarogyaApp.swift
+++ b/AarogyaiOS/App/AarogyaApp.swift
@@ -4,7 +4,6 @@ import SwiftData
 @main
 struct AarogyaApp: App {
     @State private var container = DependencyContainer()
-    @State private var coordinator: AppCoordinator?
 
     var body: some Scene {
         WindowGroup {
@@ -33,12 +32,15 @@ struct RootView: View {
             case .unauthenticated:
                 LoginView(viewModel: LoginViewModel(
                     loginUseCase: container.loginUseCase,
-                    onLoginSuccess: { await coordinator.handleLogin() }
+                    onLoginSuccess: {
+                        await coordinator.handleLogin()
+                        coordinator.consumePendingDeepLink()
+                    }
                 ))
             case .pendingApproval:
                 PendingApprovalView(
                     checkStatusUseCase: container.checkRegistrationStatusUseCase,
-                    onStatusChange: { status in
+                    onStatusChange: { _ in
                         Task { await coordinator.handleRegistrationComplete() }
                     },
                     onSignOut: {
@@ -55,13 +57,18 @@ struct RootView: View {
             case .authenticated:
                 TabCoordinator(
                     container: container,
+                    selectedTab: $coordinator.selectedTab,
                     onSignOut: { await coordinator.handleLogout() }
                 )
             }
         }
         .environment(coordinator)
+        .onOpenURL { url in
+            coordinator.handleURL(url)
+        }
         .task {
             await coordinator.checkAuthState()
+            coordinator.consumePendingDeepLink()
         }
     }
 }

--- a/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
@@ -13,6 +13,8 @@ final class AppCoordinator {
     }
 
     var state: AppState = .loading
+    var pendingDeepLink: DeepLink?
+    var selectedTab: AppTab = .reports
 
     private let container: DependencyContainer
 
@@ -66,5 +68,40 @@ final class AppCoordinator {
 
     func handleRegistrationComplete() async {
         await checkAuthState()
+    }
+
+    func handleDeepLink(_ deepLink: DeepLink) {
+        switch state {
+        case .authenticated:
+            applyDeepLink(deepLink)
+        default:
+            pendingDeepLink = deepLink
+        }
+    }
+
+    func handleURL(_ url: URL) {
+        guard let deepLink = DeepLinkHandler.parse(url: url) else { return }
+        handleDeepLink(deepLink)
+    }
+
+    func consumePendingDeepLink() {
+        guard let deepLink = pendingDeepLink else { return }
+        pendingDeepLink = nil
+        applyDeepLink(deepLink)
+    }
+
+    private func applyDeepLink(_ deepLink: DeepLink) {
+        switch deepLink {
+        case .reports:
+            selectedTab = .reports
+        case .reportDetail:
+            selectedTab = .reports
+        case .accessGrants:
+            selectedTab = .access
+        case .emergency:
+            selectedTab = .emergency
+        case .settings:
+            selectedTab = .settings
+        }
     }
 }

--- a/AarogyaiOS/Presentation/Navigation/DeepLinkHandler.swift
+++ b/AarogyaiOS/Presentation/Navigation/DeepLinkHandler.swift
@@ -1,0 +1,85 @@
+import Foundation
+import OSLog
+
+enum DeepLink: Sendable {
+    case reportDetail(id: String)
+    case reports
+    case accessGrants
+    case emergency
+    case settings
+}
+
+@MainActor
+struct DeepLinkHandler {
+    private static let customScheme = "aarogya"
+    private static let universalLinkHost = "app.aarogya.kinvee.in"
+
+    static func parse(url: URL) -> DeepLink? {
+        if url.scheme == customScheme {
+            return parseCustomScheme(url: url)
+        }
+
+        if url.host() == universalLinkHost {
+            return parseUniversalLink(url: url)
+        }
+
+        Logger.navigation.warning("Unrecognized deep link: \(url.absoluteString)")
+        return nil
+    }
+
+    static func parse(notificationRoute: String) -> DeepLink? {
+        let components = notificationRoute.split(separator: "/")
+        guard let first = components.first else { return nil }
+
+        switch first {
+        case "reports":
+            if components.count > 1 {
+                return .reportDetail(id: String(components[1]))
+            }
+            return .reports
+        case "access-grants":
+            return .accessGrants
+        case "emergency":
+            return .emergency
+        case "settings":
+            return .settings
+        default:
+            Logger.navigation.warning("Unrecognized notification route: \(notificationRoute)")
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    private static func parseCustomScheme(url: URL) -> DeepLink? {
+        let pathComponents = url.host().map { [$0] + url.pathComponents.filter { $0 != "/" } }
+            ?? url.pathComponents.filter { $0 != "/" }
+
+        return matchPath(pathComponents)
+    }
+
+    private static func parseUniversalLink(url: URL) -> DeepLink? {
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+        return matchPath(pathComponents)
+    }
+
+    private static func matchPath(_ components: [String]) -> DeepLink? {
+        guard let first = components.first else { return nil }
+
+        switch first {
+        case "reports":
+            if components.count > 1 {
+                return .reportDetail(id: components[1])
+            }
+            return .reports
+        case "access-grants":
+            return .accessGrants
+        case "emergency":
+            return .emergency
+        case "settings":
+            return .settings
+        default:
+            return nil
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -9,9 +9,8 @@ enum AppTab: String, CaseIterable, Sendable {
 
 struct TabCoordinator: View {
     let container: DependencyContainer
+    @Binding var selectedTab: AppTab
     let onSignOut: () async -> Void
-
-    @State private var selectedTab: AppTab = .reports
 
     var body: some View {
         TabView(selection: $selectedTab) {

--- a/AarogyaiOS/Resources/AarogyaiOS.entitlements
+++ b/AarogyaiOS/Resources/AarogyaiOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.aarogya.kinvee.in</string>
+	</array>
+</dict>
+</plist>

--- a/AarogyaiOS/Utilities/Logger.swift
+++ b/AarogyaiOS/Utilities/Logger.swift
@@ -9,4 +9,5 @@ extension Logger {
     static let ui = Logger(subsystem: subsystem, category: "ui")
     static let upload = Logger(subsystem: subsystem, category: "upload")
     static let cache = Logger(subsystem: subsystem, category: "cache")
+    static let navigation = Logger(subsystem: subsystem, category: "navigation")
 }

--- a/project.yml
+++ b/project.yml
@@ -37,6 +37,7 @@ targets:
         PRODUCT_NAME: AarogyaiOS
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         GENERATE_INFOPLIST_FILE: false
+        CODE_SIGN_ENTITLEMENTS: AarogyaiOS/Resources/AarogyaiOS.entitlements
       configs:
         Debug:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG


### PR DESCRIPTION
## Summary
- Add `DeepLinkHandler` parsing URL scheme (`aarogya://`) and universal links (`app.aarogya.kinvee.in`)
- Support push notification route parsing via `parse(notificationRoute:)`
- Integrate with `AppCoordinator` for auth-aware deep link routing with pending queue
- Add associated domains entitlement for universal link support
- Pass `selectedTab` binding from coordinator to `TabCoordinator` for programmatic tab switching

Closes #57

## Test plan
- [ ] Build succeeds on iOS 26 simulator
- [ ] Existing UI tests pass
- [ ] Custom URL scheme `aarogya://reports` switches to reports tab
- [ ] Universal link `https://app.aarogya.kinvee.in/emergency` routes correctly
- [ ] Deep links received while unauthenticated are queued and applied after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)