### PR TITLE
feat(ui): add launch screen with Serene Bloom gradient

### DIFF
--- a/AarogyaiOS/App/LaunchScreen.swift
+++ b/AarogyaiOS/App/LaunchScreen.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct LaunchScreen: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color.Fallback.bgGradientStart,
+                    Color.Fallback.bgGradientEnd
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            Image(systemName: "heart.text.clipboard")
+                .font(.system(size: 80, weight: .light))
+                .foregroundStyle(Color.Fallback.brandPrimary)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LaunchScreen` SwiftUI view with brand gradient background and healthcare icon
- AppIcon.appiconset configured for iOS 26+ single 1024x1024 (icon image to be added by designer)

Closes #67

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] Launch screen shows gradient background

🤖 Generated with [Claude Code](https://claude.com/claude-code)