### PR TITLE
test(ui): add comprehensive E2E UI tests for all app flows

### DIFF
--- a/AarogyaiOS/App/DependencyContainer.swift
+++ b/AarogyaiOS/App/DependencyContainer.swift
@@ -7,7 +7,7 @@ final class DependencyContainer {
 
     let networkMonitor: NetworkMonitor
     let keychainService: KeychainService
-    let tokenStore: TokenStore
+    let tokenStore: any TokenStoring
     let s3UploadService: S3UploadService
     let pushService: any PushNotificationService
 
@@ -64,18 +64,13 @@ final class DependencyContainer {
     let manageConsentsUseCase: ManageConsentsUseCase
     let manageNotificationsUseCase: ManageNotificationsUseCase
 
+    // swiftlint:disable function_body_length
     init() {
-        // Infrastructure
         networkMonitor = NetworkMonitor()
         networkMonitor.start()
-
         keychainService = KeychainService(service: Constants.Keychain.serviceName)
-        tokenStore = TokenStore(keychain: keychainService)
-
-        s3UploadService = S3UploadService()
         pushService = MockPushService()
 
-        // Persistence
         do {
             modelContainer = try LocalDataSource.makeContainer()
         } catch {
@@ -83,60 +78,266 @@ final class DependencyContainer {
         }
         localDataSource = LocalDataSource(modelContainer: modelContainer)
 
-        // Networking
-        let tokenStoreRef: any TokenStoring = tokenStore
-        authInterceptor = AuthInterceptor(
-            tokenStore: tokenStoreRef,
+        if UITestingMode.isUITesting {
+            let deps = Self.makeStubDependencies()
+            tokenStore = deps.tokenStore
+            s3UploadService = S3UploadService()
+            authInterceptor = deps.interceptor
+            apiClient = deps.client
+            authRepository = deps.auth
+            userRepository = deps.user
+            reportRepository = deps.report
+            accessGrantRepository = deps.accessGrant
+            emergencyContactRepository = deps.emergency
+            consentRepository = deps.consent
+            notificationRepository = deps.notification
+            loginUseCase = deps.login
+            logoutUseCase = deps.logout
+            refreshTokenUseCase = deps.refresh
+            registerUserUseCase = deps.register
+            getCurrentUserUseCase = deps.getCurrentUser
+            updateProfileUseCase = deps.updateProfile
+            checkRegistrationStatusUseCase = deps.checkStatus
+            verifyAadhaarUseCase = deps.verifyAadhaar
+            exportDataUseCase = deps.exportData
+            requestAccountDeletionUseCase = deps.deleteAccount
+            fetchReportsUseCase = deps.fetchReports
+            uploadReportUseCase = deps.uploadReport
+            deleteReportUseCase = deps.deleteReport
+            downloadReportUseCase = deps.downloadReport
+            fetchAccessGrantsUseCase = deps.fetchGrants
+            createAccessGrantUseCase = deps.createGrant
+            revokeAccessGrantUseCase = deps.revokeGrant
+            fetchEmergencyContactsUseCase = deps.fetchContacts
+            manageEmergencyContactUseCase = deps.manageContact
+            manageConsentsUseCase = deps.manageConsents
+            manageNotificationsUseCase = deps.manageNotifications
+        } else {
+            let deps = Self.makeProductionDependencies(
+                keychainService: keychainService
+            )
+            tokenStore = deps.tokenStore
+            s3UploadService = S3UploadService()
+            authInterceptor = deps.interceptor
+            apiClient = deps.client
+            authRepository = deps.auth
+            userRepository = deps.user
+            reportRepository = deps.report
+            accessGrantRepository = deps.accessGrant
+            emergencyContactRepository = deps.emergency
+            consentRepository = deps.consent
+            notificationRepository = deps.notification
+            loginUseCase = deps.login
+            logoutUseCase = deps.logout
+            refreshTokenUseCase = deps.refresh
+            registerUserUseCase = deps.register
+            getCurrentUserUseCase = deps.getCurrentUser
+            updateProfileUseCase = deps.updateProfile
+            checkRegistrationStatusUseCase = deps.checkStatus
+            verifyAadhaarUseCase = deps.verifyAadhaar
+            exportDataUseCase = deps.exportData
+            requestAccountDeletionUseCase = deps.deleteAccount
+            fetchReportsUseCase = deps.fetchReports
+            uploadReportUseCase = deps.uploadReport
+            deleteReportUseCase = deps.deleteReport
+            downloadReportUseCase = deps.downloadReport
+            fetchAccessGrantsUseCase = deps.fetchGrants
+            createAccessGrantUseCase = deps.createGrant
+            revokeAccessGrantUseCase = deps.revokeGrant
+            fetchEmergencyContactsUseCase = deps.fetchContacts
+            manageEmergencyContactUseCase = deps.manageContact
+            manageConsentsUseCase = deps.manageConsents
+            manageNotificationsUseCase = deps.manageNotifications
+        }
+    }
+    // swiftlint:enable function_body_length
+}
+
+// MARK: - Dependency Bundle
+
+private struct DependencyBundle {
+    let tokenStore: any TokenStoring
+    let interceptor: AuthInterceptor
+    let client: APIClient
+    let auth: any AuthRepository
+    let user: any UserRepository
+    let report: any ReportRepository
+    let accessGrant: any AccessGrantRepository
+    let emergency: any EmergencyContactRepository
+    let consent: any ConsentRepository
+    let notification: any NotificationRepository
+    let login: LoginUseCase
+    let logout: LogoutUseCase
+    let refresh: RefreshTokenUseCase
+    let register: RegisterUserUseCase
+    let getCurrentUser: GetCurrentUserUseCase
+    let updateProfile: UpdateProfileUseCase
+    let checkStatus: CheckRegistrationStatusUseCase
+    let verifyAadhaar: VerifyAadhaarUseCase
+    let exportData: ExportDataUseCase
+    let deleteAccount: RequestAccountDeletionUseCase
+    let fetchReports: FetchReportsUseCase
+    let uploadReport: UploadReportUseCase
+    let deleteReport: DeleteReportUseCase
+    let downloadReport: DownloadReportUseCase
+    let fetchGrants: FetchAccessGrantsUseCase
+    let createGrant: CreateAccessGrantUseCase
+    let revokeGrant: RevokeAccessGrantUseCase
+    let fetchContacts: FetchEmergencyContactsUseCase
+    let manageContact: ManageEmergencyContactUseCase
+    let manageConsents: ManageConsentsUseCase
+    let manageNotifications: ManageNotificationsUseCase
+}
+
+// MARK: - Factory Methods
+
+extension DependencyContainer {
+    private static func makeStubDependencies() -> DependencyBundle {
+        let store = StubTokenStore(preloaded: !UITestingMode.isLoginFlow)
+        let authRepo = StubAuthRepository(tokenStore: store)
+        let userRepo = StubUserRepository(tokenStore: store)
+        let reportRepo = StubReportRepository()
+        let grantRepo = StubAccessGrantRepository()
+        let emergencyRepo = StubEmergencyContactRepository()
+        let consentRepo = StubConsentRepository()
+        let notifRepo = StubNotificationRepository()
+
+        let interceptor = AuthInterceptor(tokenStore: store, refreshToken: {
+            AuthTokens(
+                accessToken: "stub", refreshToken: "stub",
+                idToken: "stub", expiresIn: 3600
+            )
+        })
+        let client = APIClient(
+            baseURL: Constants.API.baseURL,
+            interceptor: interceptor
+        )
+
+        return DependencyBundle(
+            tokenStore: store,
+            interceptor: interceptor,
+            client: client,
+            auth: authRepo, user: userRepo,
+            report: reportRepo, accessGrant: grantRepo,
+            emergency: emergencyRepo, consent: consentRepo,
+            notification: notifRepo,
+            login: LoginUseCase(authRepository: authRepo, tokenStore: store),
+            logout: LogoutUseCase(authRepository: authRepo, tokenStore: store),
+            refresh: RefreshTokenUseCase(authRepository: authRepo, tokenStore: store),
+            register: RegisterUserUseCase(userRepository: userRepo),
+            getCurrentUser: GetCurrentUserUseCase(userRepository: userRepo),
+            updateProfile: UpdateProfileUseCase(userRepository: userRepo),
+            checkStatus: CheckRegistrationStatusUseCase(userRepository: userRepo),
+            verifyAadhaar: VerifyAadhaarUseCase(userRepository: userRepo),
+            exportData: ExportDataUseCase(userRepository: userRepo),
+            deleteAccount: RequestAccountDeletionUseCase(userRepository: userRepo),
+            fetchReports: FetchReportsUseCase(reportRepository: reportRepo),
+            uploadReport: UploadReportUseCase(
+                reportRepository: reportRepo, uploadService: StubFileUploader()
+            ),
+            deleteReport: DeleteReportUseCase(reportRepository: reportRepo),
+            downloadReport: DownloadReportUseCase(reportRepository: reportRepo),
+            fetchGrants: FetchAccessGrantsUseCase(accessGrantRepository: grantRepo),
+            createGrant: CreateAccessGrantUseCase(accessGrantRepository: grantRepo),
+            revokeGrant: RevokeAccessGrantUseCase(accessGrantRepository: grantRepo),
+            fetchContacts: FetchEmergencyContactsUseCase(
+                emergencyContactRepository: emergencyRepo
+            ),
+            manageContact: ManageEmergencyContactUseCase(
+                emergencyContactRepository: emergencyRepo
+            ),
+            manageConsents: ManageConsentsUseCase(consentRepository: consentRepo),
+            manageNotifications: ManageNotificationsUseCase(
+                notificationRepository: notifRepo
+            )
+        )
+    }
+
+    private static func makeProductionDependencies(
+        keychainService: KeychainService
+    ) -> DependencyBundle {
+        let store = TokenStore(keychain: keychainService)
+        let tokenRef: any TokenStoring = store
+
+        let interceptor = AuthInterceptor(
+            tokenStore: tokenRef,
             refreshToken: {
                 let refreshClient = APIClient(baseURL: Constants.API.baseURL)
-                let repo = DefaultAuthRepository(apiClient: refreshClient, tokenStore: tokenStoreRef)
-                let currentRefreshToken = try await tokenStoreRef.refreshToken()
-                return try await repo.refreshToken(refreshToken: currentRefreshToken)
+                let repo = DefaultAuthRepository(
+                    apiClient: refreshClient, tokenStore: tokenRef
+                )
+                let token = try await tokenRef.refreshToken()
+                return try await repo.refreshToken(refreshToken: token)
             }
         )
-        apiClient = APIClient(
-            baseURL: Constants.API.baseURL,
-            interceptor: authInterceptor
+        let client = APIClient(
+            baseURL: Constants.API.baseURL, interceptor: interceptor
         )
 
-        // Repositories
-        authRepository = DefaultAuthRepository(apiClient: apiClient, tokenStore: tokenStore)
-        userRepository = DefaultUserRepository(apiClient: apiClient)
-        reportRepository = DefaultReportRepository(apiClient: apiClient)
-        accessGrantRepository = DefaultAccessGrantRepository(apiClient: apiClient)
-        emergencyContactRepository = DefaultEmergencyContactRepository(apiClient: apiClient)
-        consentRepository = DefaultConsentRepository(apiClient: apiClient)
-        notificationRepository = DefaultNotificationRepository(apiClient: apiClient)
+        let authRepo = DefaultAuthRepository(
+            apiClient: client, tokenStore: store
+        )
+        let userRepo = DefaultUserRepository(apiClient: client)
+        let reportRepo = DefaultReportRepository(apiClient: client)
+        let grantRepo = DefaultAccessGrantRepository(apiClient: client)
+        let emergencyRepo = DefaultEmergencyContactRepository(apiClient: client)
+        let consentRepo = DefaultConsentRepository(apiClient: client)
+        let notifRepo = DefaultNotificationRepository(apiClient: client)
 
-        // Use Cases — Auth
-        loginUseCase = LoginUseCase(authRepository: authRepository, tokenStore: tokenStore)
-        logoutUseCase = LogoutUseCase(authRepository: authRepository, tokenStore: tokenStore)
-        refreshTokenUseCase = RefreshTokenUseCase(authRepository: authRepository, tokenStore: tokenStore)
-        registerUserUseCase = RegisterUserUseCase(userRepository: userRepository)
-        getCurrentUserUseCase = GetCurrentUserUseCase(userRepository: userRepository)
-        updateProfileUseCase = UpdateProfileUseCase(userRepository: userRepository)
-        checkRegistrationStatusUseCase = CheckRegistrationStatusUseCase(userRepository: userRepository)
-        verifyAadhaarUseCase = VerifyAadhaarUseCase(userRepository: userRepository)
-        exportDataUseCase = ExportDataUseCase(userRepository: userRepository)
-        requestAccountDeletionUseCase = RequestAccountDeletionUseCase(userRepository: userRepository)
-
-        // Use Cases — Reports
-        fetchReportsUseCase = FetchReportsUseCase(reportRepository: reportRepository)
-        uploadReportUseCase = UploadReportUseCase(reportRepository: reportRepository, uploadService: s3UploadService)
-        deleteReportUseCase = DeleteReportUseCase(reportRepository: reportRepository)
-        downloadReportUseCase = DownloadReportUseCase(reportRepository: reportRepository)
-
-        // Use Cases — Access Grants
-        fetchAccessGrantsUseCase = FetchAccessGrantsUseCase(accessGrantRepository: accessGrantRepository)
-        createAccessGrantUseCase = CreateAccessGrantUseCase(accessGrantRepository: accessGrantRepository)
-        revokeAccessGrantUseCase = RevokeAccessGrantUseCase(accessGrantRepository: accessGrantRepository)
-
-        // Use Cases — Emergency Contacts
-        fetchEmergencyContactsUseCase = FetchEmergencyContactsUseCase(emergencyContactRepository: emergencyContactRepository)
-        manageEmergencyContactUseCase = ManageEmergencyContactUseCase(emergencyContactRepository: emergencyContactRepository)
-
-        // Use Cases — Consents & Notifications
-        manageConsentsUseCase = ManageConsentsUseCase(consentRepository: consentRepository)
-        manageNotificationsUseCase = ManageNotificationsUseCase(notificationRepository: notificationRepository)
+        return DependencyBundle(
+            tokenStore: store,
+            interceptor: interceptor,
+            client: client,
+            auth: authRepo, user: userRepo,
+            report: reportRepo, accessGrant: grantRepo,
+            emergency: emergencyRepo, consent: consentRepo,
+            notification: notifRepo,
+            login: LoginUseCase(authRepository: authRepo, tokenStore: store),
+            logout: LogoutUseCase(authRepository: authRepo, tokenStore: store),
+            refresh: RefreshTokenUseCase(
+                authRepository: authRepo, tokenStore: store
+            ),
+            register: RegisterUserUseCase(userRepository: userRepo),
+            getCurrentUser: GetCurrentUserUseCase(userRepository: userRepo),
+            updateProfile: UpdateProfileUseCase(userRepository: userRepo),
+            checkStatus: CheckRegistrationStatusUseCase(
+                userRepository: userRepo
+            ),
+            verifyAadhaar: VerifyAadhaarUseCase(userRepository: userRepo),
+            exportData: ExportDataUseCase(userRepository: userRepo),
+            deleteAccount: RequestAccountDeletionUseCase(
+                userRepository: userRepo
+            ),
+            fetchReports: FetchReportsUseCase(reportRepository: reportRepo),
+            uploadReport: UploadReportUseCase(
+                reportRepository: reportRepo,
+                uploadService: S3UploadService()
+            ),
+            deleteReport: DeleteReportUseCase(reportRepository: reportRepo),
+            downloadReport: DownloadReportUseCase(
+                reportRepository: reportRepo
+            ),
+            fetchGrants: FetchAccessGrantsUseCase(
+                accessGrantRepository: grantRepo
+            ),
+            createGrant: CreateAccessGrantUseCase(
+                accessGrantRepository: grantRepo
+            ),
+            revokeGrant: RevokeAccessGrantUseCase(
+                accessGrantRepository: grantRepo
+            ),
+            fetchContacts: FetchEmergencyContactsUseCase(
+                emergencyContactRepository: emergencyRepo
+            ),
+            manageContact: ManageEmergencyContactUseCase(
+                emergencyContactRepository: emergencyRepo
+            ),
+            manageConsents: ManageConsentsUseCase(
+                consentRepository: consentRepo
+            ),
+            manageNotifications: ManageNotificationsUseCase(
+                notificationRepository: notifRepo
+            )
+        )
     }
 }

--- a/AarogyaiOS/App/UITestingStubs.swift
+++ b/AarogyaiOS/App/UITestingStubs.swift
@@ -1,0 +1,531 @@
+import Foundation
+
+// MARK: - UI Testing Detection
+
+enum UITestingMode {
+    static var isUITesting: Bool {
+        ProcessInfo.processInfo.arguments.contains("-ui-testing")
+            || ProcessInfo.processInfo.arguments.contains("-ui-testing-login")
+    }
+
+    static var isLoginFlow: Bool {
+        ProcessInfo.processInfo.arguments.contains("-ui-testing-login")
+    }
+}
+
+// MARK: - Stub Token Store
+
+final class StubTokenStore: TokenStoring, @unchecked Sendable {
+    private var tokens: AuthTokens?
+
+    init(preloaded: Bool = true) {
+        if preloaded {
+            tokens = AuthTokens(
+                accessToken: "ui-test-access-token",
+                refreshToken: "ui-test-refresh-token",
+                idToken: "ui-test-id-token",
+                expiresIn: 3600
+            )
+        }
+    }
+
+    func store(_ tokens: AuthTokens) async throws {
+        self.tokens = tokens
+    }
+
+    func accessToken() async throws -> String {
+        guard let tokens else { throw APIError.unauthorized }
+        return tokens.accessToken
+    }
+
+    func refreshToken() async throws -> String {
+        guard let tokens else { throw APIError.unauthorized }
+        return tokens.refreshToken
+    }
+
+    func idToken() async throws -> String {
+        guard let tokens else { throw APIError.unauthorized }
+        return tokens.idToken
+    }
+
+    func clearAll() async throws {
+        tokens = nil
+    }
+}
+
+// MARK: - Stub Auth Repository
+
+final class StubAuthRepository: AuthRepository, @unchecked Sendable {
+    private let tokenStore: StubTokenStore
+
+    init(tokenStore: StubTokenStore = StubTokenStore(preloaded: true)) {
+        self.tokenStore = tokenStore
+    }
+
+    func socialAuthorize(provider: String) async throws -> URL {
+        URL(string: "https://auth.example.com")!
+    }
+
+    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {
+        AuthTokens(accessToken: "stub-access", refreshToken: "stub-refresh", idToken: "stub-id", expiresIn: 3600)
+    }
+
+    func requestOTP(phone: String) async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+
+    func verifyOTP(phone: String, otp: String) async throws -> AuthTokens {
+        try await Task.sleep(for: .milliseconds(300))
+        return AuthTokens(accessToken: "stub-access", refreshToken: "stub-refresh", idToken: "stub-id", expiresIn: 3600)
+    }
+
+    func refreshToken(refreshToken: String) async throws -> AuthTokens {
+        AuthTokens(accessToken: "stub-access", refreshToken: "stub-refresh", idToken: "stub-id", expiresIn: 3600)
+    }
+
+    func revokeToken(refreshToken: String) async throws {}
+
+    func getCurrentUser() async throws -> User {
+        // If no token, simulate 401 like real API
+        _ = try await tokenStore.accessToken()
+        return .uiTestStub
+    }
+}
+
+// MARK: - Stub User Repository
+
+final class StubUserRepository: UserRepository, @unchecked Sendable {
+    private let tokenStore: StubTokenStore
+
+    init(tokenStore: StubTokenStore = StubTokenStore(preloaded: true)) {
+        self.tokenStore = tokenStore
+    }
+
+    func getProfile() async throws -> User {
+        // If no token, simulate 401 like real API
+        _ = try await tokenStore.accessToken()
+        return .uiTestStub
+    }
+
+    func updateProfile(_ user: User) async throws -> User {
+        try await Task.sleep(for: .milliseconds(200))
+        return user
+    }
+
+    func register(request: RegistrationRequest) async throws -> User {
+        .uiTestStub
+    }
+
+    func getRegistrationStatus() async throws -> RegistrationStatus {
+        .approved
+    }
+
+    func verifyAadhaar(token: String) async throws -> User {
+        .uiTestStub
+    }
+
+    func exportData() async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+
+    func requestDeletion() async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+}
+
+// MARK: - Stub Report Repository
+
+final class StubReportRepository: ReportRepository, @unchecked Sendable {
+    func getReports(page: Int, pageSize: Int, type: ReportType?, status: ReportStatus?, search: String?) async throws -> PaginatedResult<Report> {
+        try await Task.sleep(for: .milliseconds(200))
+        let reports = Report.uiTestStubs
+        let filtered: [Report]
+        if let type {
+            filtered = reports.filter { $0.reportType == type }
+        } else if let search, !search.isEmpty {
+            filtered = reports.filter { $0.title.localizedCaseInsensitiveContains(search) }
+        } else {
+            filtered = reports
+        }
+        return PaginatedResult(items: filtered, page: 1, pageSize: pageSize, totalCount: filtered.count)
+    }
+
+    func getReport(id: String) async throws -> Report {
+        Report.uiTestStubs.first { $0.id == id } ?? Report.uiTestStubs[0]
+    }
+
+    func createReport(request: CreateReportInput) async throws -> Report {
+        Report.uiTestStubs[0]
+    }
+
+    func deleteReport(id: String) async throws {
+        try await Task.sleep(for: .milliseconds(200))
+    }
+
+    func getUploadURL(fileName: String, contentType: String) async throws -> PresignedUpload {
+        PresignedUpload(uploadURL: URL(string: "https://s3.example.com/upload")!, fileStorageKey: "reports/\(fileName)")
+    }
+
+    func getDownloadURL(reportId: String) async throws -> URL {
+        URL(string: "https://cdn.example.com/report.pdf")!
+    }
+
+    func getExtractionStatus(reportId: String) async throws -> ReportExtraction {
+        ReportExtraction(
+            status: .completed,
+            extractionMethod: "ai",
+            structuringModel: "gpt-4",
+            extractedParameterCount: 12,
+            overallConfidence: 0.95,
+            pageCount: 2,
+            extractedAt: .now,
+            errorMessage: nil,
+            attemptCount: 1
+        )
+    }
+
+    func triggerExtraction(reportId: String) async throws {}
+}
+
+// MARK: - Stub Access Grant Repository
+
+final class StubAccessGrantRepository: AccessGrantRepository, @unchecked Sendable {
+    func createGrant(request: CreateAccessGrantInput) async throws -> AccessGrant {
+        try await Task.sleep(for: .milliseconds(200))
+        return AccessGrant.uiTestStubs[0]
+    }
+
+    func getGrants() async throws -> [AccessGrant] {
+        try await Task.sleep(for: .milliseconds(200))
+        return AccessGrant.uiTestStubs
+    }
+
+    func getReceivedGrants() async throws -> [AccessGrant] {
+        try await Task.sleep(for: .milliseconds(200))
+        return [AccessGrant.uiTestReceivedStub]
+    }
+
+    func revokeGrant(id: String) async throws {
+        try await Task.sleep(for: .milliseconds(200))
+    }
+}
+
+// MARK: - Stub Emergency Contact Repository
+
+final class StubEmergencyContactRepository: EmergencyContactRepository, @unchecked Sendable {
+    func getContacts() async throws -> [EmergencyContact] {
+        try await Task.sleep(for: .milliseconds(200))
+        return EmergencyContact.uiTestStubs
+    }
+
+    func createContact(request: EmergencyContactInput) async throws -> EmergencyContact {
+        try await Task.sleep(for: .milliseconds(200))
+        return EmergencyContact(
+            id: UUID().uuidString,
+            name: request.name,
+            phone: request.phone,
+            relationship: request.relationship,
+            isPrimary: request.isPrimary,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+
+    func updateContact(id: String, request: EmergencyContactInput) async throws -> EmergencyContact {
+        try await Task.sleep(for: .milliseconds(200))
+        return EmergencyContact(
+            id: id,
+            name: request.name,
+            phone: request.phone,
+            relationship: request.relationship,
+            isPrimary: request.isPrimary,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+
+    func deleteContact(id: String) async throws {
+        try await Task.sleep(for: .milliseconds(200))
+    }
+
+    func requestEmergencyAccess(contactPhone: String) async throws {}
+}
+
+// MARK: - Stub Consent Repository
+
+final class StubConsentRepository: ConsentRepository, @unchecked Sendable {
+    func upsertConsent(purpose: ConsentPurpose, isGranted: Bool) async throws -> ConsentRecord {
+        try await Task.sleep(for: .milliseconds(100))
+        return ConsentRecord(purpose: purpose, isGranted: isGranted, source: "app", occurredAt: .now)
+    }
+}
+
+// MARK: - Stub Notification Repository
+
+final class StubNotificationRepository: NotificationRepository, @unchecked Sendable {
+    func getPreferences() async throws -> NotificationPreferences {
+        try await Task.sleep(for: .milliseconds(200))
+        return NotificationPreferences(
+            reportUploaded: ChannelPreferences(push: true, email: true, sms: false),
+            accessGranted: ChannelPreferences(push: true, email: false, sms: false),
+            emergencyAccess: ChannelPreferences(push: true, email: true, sms: true)
+        )
+    }
+
+    func updatePreferences(_ preferences: NotificationPreferences) async throws -> NotificationPreferences {
+        try await Task.sleep(for: .milliseconds(200))
+        return preferences
+    }
+
+    func registerDevice(token: String) async throws -> DeviceToken {
+        DeviceToken(id: "dt-1", deviceToken: token, platform: "ios", deviceName: "iPhone", appVersion: "1.0", registeredAt: .now, updatedAt: .now)
+    }
+
+    func unregisterDevice(token: String) async throws {}
+}
+
+// MARK: - Stub File Uploader
+
+final class StubFileUploader: FileUploading, @unchecked Sendable {
+    func upload(
+        data: Data,
+        to url: URL,
+        contentType: String,
+        onProgress: @Sendable @escaping (Double) -> Void
+    ) async throws {
+        for step in stride(from: 0.0, through: 1.0, by: 0.2) {
+            try await Task.sleep(for: .milliseconds(100))
+            onProgress(step)
+        }
+        onProgress(1.0)
+    }
+}
+
+// MARK: - UI Test Stub Data
+
+extension User {
+    static let uiTestStub = User(
+        id: "user-ui-test",
+        firstName: "Priya",
+        lastName: "Sharma",
+        email: "priya.sharma@example.com",
+        phone: "+919876543210",
+        address: "123 MG Road, Bangalore 560001",
+        bloodGroup: .bPositive,
+        dateOfBirth: Date(timeIntervalSince1970: 852_076_800), // 1997-01-01
+        gender: .female,
+        role: .patient,
+        registrationStatus: .approved,
+        isAadhaarVerified: true,
+        aadhaarRefToken: nil,
+        doctorProfile: nil,
+        labTechProfile: nil,
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+        updatedAt: .now
+    )
+}
+
+extension Report {
+    static let uiTestStubs: [Report] = [
+        Report(
+            id: "rpt-1",
+            reportNumber: "RPT-2025-001",
+            title: "Complete Blood Count",
+            reportType: .bloodTest,
+            status: .clean,
+            patientId: "user-ui-test",
+            doctorId: "doc-1",
+            doctorName: "Dr. Anil Kumar",
+            labName: "Apollo Diagnostics",
+            collectedAt: Date(timeIntervalSinceNow: -86400 * 7),
+            reportedAt: Date(timeIntervalSinceNow: -86400 * 6),
+            uploadedAt: Date(timeIntervalSinceNow: -86400 * 5),
+            notes: "Routine annual checkup",
+            fileStorageKey: "reports/cbc.pdf",
+            fileType: "application/pdf",
+            fileSizeBytes: 245_000,
+            checksumSha256: nil,
+            parameters: [
+                ReportParameter(
+                    id: "p-1", code: "HGB", name: "Hemoglobin",
+                    numericValue: 13.5, textValue: "13.5",
+                    unit: "g/dL", referenceRange: "12.0-15.5",
+                    isAbnormal: false
+                ),
+                ReportParameter(
+                    id: "p-2", code: "WBC", name: "WBC Count",
+                    numericValue: 7200, textValue: "7200",
+                    unit: "/cumm", referenceRange: "4000-11000",
+                    isAbnormal: false
+                ),
+                ReportParameter(
+                    id: "p-3", code: "PLT", name: "Platelet Count",
+                    numericValue: 280_000, textValue: "280000",
+                    unit: "/cumm", referenceRange: "150000-400000",
+                    isAbnormal: false
+                ),
+            ],
+            extraction: ReportExtraction(
+                status: .completed, extractionMethod: "ai",
+                structuringModel: "gpt-4",
+                extractedParameterCount: 3,
+                overallConfidence: 0.97, pageCount: 2,
+                extractedAt: .now, errorMessage: nil,
+                attemptCount: 1
+            ),
+            highlightParameter: nil,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 5),
+            updatedAt: .now
+        ),
+        Report(
+            id: "rpt-2",
+            reportNumber: "RPT-2025-002",
+            title: "Urine Analysis",
+            reportType: .urineTest,
+            status: .clean,
+            patientId: "user-ui-test",
+            doctorId: nil,
+            doctorName: "Dr. Meera Patel",
+            labName: "SRL Diagnostics",
+            collectedAt: Date(timeIntervalSinceNow: -86400 * 3),
+            reportedAt: Date(timeIntervalSinceNow: -86400 * 2),
+            uploadedAt: Date(timeIntervalSinceNow: -86400 * 2),
+            notes: nil,
+            fileStorageKey: "reports/urine.pdf",
+            fileType: "application/pdf",
+            fileSizeBytes: 180_000,
+            checksumSha256: nil,
+            parameters: [],
+            extraction: nil,
+            highlightParameter: nil,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 2),
+            updatedAt: .now
+        ),
+        Report(
+            id: "rpt-3",
+            reportNumber: "RPT-2025-003",
+            title: "Chest X-Ray",
+            reportType: .radiology,
+            status: .validated,
+            patientId: "user-ui-test",
+            doctorId: nil,
+            doctorName: "Dr. Rajesh Verma",
+            labName: "Max Healthcare",
+            collectedAt: Date(timeIntervalSinceNow: -86400 * 14),
+            reportedAt: Date(timeIntervalSinceNow: -86400 * 13),
+            uploadedAt: Date(timeIntervalSinceNow: -86400 * 12),
+            notes: "Follow-up for persistent cough",
+            fileStorageKey: "reports/xray.pdf",
+            fileType: "application/pdf",
+            fileSizeBytes: 520_000,
+            checksumSha256: nil,
+            parameters: [],
+            extraction: nil,
+            highlightParameter: nil,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 12),
+            updatedAt: .now
+        ),
+        Report(
+            id: "rpt-4",
+            reportNumber: "RPT-2025-004",
+            title: "ECG Report",
+            reportType: .cardiology,
+            status: .clean,
+            patientId: "user-ui-test",
+            doctorId: nil,
+            doctorName: "Dr. Sanjay Gupta",
+            labName: "Fortis Hospital",
+            collectedAt: Date(timeIntervalSinceNow: -86400),
+            reportedAt: Date(timeIntervalSinceNow: -86400),
+            uploadedAt: .now,
+            notes: nil,
+            fileStorageKey: "reports/ecg.pdf",
+            fileType: "application/pdf",
+            fileSizeBytes: 310_000,
+            checksumSha256: nil,
+            parameters: [],
+            extraction: ReportExtraction(
+                status: .pending, extractionMethod: nil,
+                structuringModel: nil,
+                extractedParameterCount: 0,
+                overallConfidence: nil, pageCount: nil,
+                extractedAt: nil, errorMessage: nil,
+                attemptCount: 0
+            ),
+            highlightParameter: nil,
+            createdAt: .now,
+            updatedAt: .now
+        ),
+    ]
+}
+
+extension AccessGrant {
+    static let uiTestStubs: [AccessGrant] = [
+        AccessGrant(
+            id: "grant-1",
+            patientId: "user-ui-test",
+            grantedToUserId: "doc-1",
+            grantedToUserName: "Dr. Anil Kumar",
+            grantedByUserId: "user-ui-test",
+            grantReason: "Annual checkup follow-up",
+            scope: AccessScope(allReports: true, reportIds: []),
+            status: .active,
+            startsAt: Date(timeIntervalSinceNow: -86400 * 30),
+            expiresAt: Date(timeIntervalSinceNow: 86400 * 60),
+            revokedAt: nil,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 30)
+        ),
+        AccessGrant(
+            id: "grant-2",
+            patientId: "user-ui-test",
+            grantedToUserId: "doc-2",
+            grantedToUserName: "Dr. Meera Patel",
+            grantedByUserId: "user-ui-test",
+            grantReason: nil,
+            scope: AccessScope(allReports: false, reportIds: ["rpt-2"]),
+            status: .expired,
+            startsAt: Date(timeIntervalSinceNow: -86400 * 90),
+            expiresAt: Date(timeIntervalSinceNow: -86400 * 30),
+            revokedAt: nil,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 90)
+        ),
+    ]
+
+    static let uiTestReceivedStub = AccessGrant(
+        id: "grant-3",
+        patientId: "patient-2",
+        grantedToUserId: "user-ui-test",
+        grantedToUserName: "Priya Sharma",
+        grantedByUserId: "patient-2",
+        grantReason: "Emergency consultation",
+        scope: AccessScope(allReports: false, reportIds: ["rpt-x"]),
+        status: .active,
+        startsAt: Date(timeIntervalSinceNow: -86400 * 5),
+        expiresAt: nil,
+        revokedAt: nil,
+        createdAt: Date(timeIntervalSinceNow: -86400 * 5)
+    )
+}
+
+extension EmergencyContact {
+    static let uiTestStubs: [EmergencyContact] = [
+        EmergencyContact(
+            id: "ec-1",
+            name: "Rahul Sharma",
+            phone: "+919876543211",
+            relationship: .spouse,
+            isPrimary: true,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 60),
+            updatedAt: .now
+        ),
+        EmergencyContact(
+            id: "ec-2",
+            name: "Sunita Sharma",
+            phone: "+919876543212",
+            relationship: .parent,
+            isPrimary: false,
+            createdAt: Date(timeIntervalSinceNow: -86400 * 30),
+            updatedAt: .now
+        ),
+    ]
+}

--- a/AarogyaiOS/Presentation/Auth/LoginView.swift
+++ b/AarogyaiOS/Presentation/Auth/LoginView.swift
@@ -33,6 +33,7 @@ struct LoginView: View {
 
             Text("Aarogya")
                 .font(Typography.largeTitle)
+                .accessibilityIdentifier(AccessibilityID.Login.title)
 
             Text("Your health records, secured")
                 .font(Typography.callout)
@@ -96,6 +97,7 @@ struct LoginView: View {
                     .font(Typography.body)
                     .keyboardType(.phonePad)
                     .textContentType(.telephoneNumber)
+                    .accessibilityIdentifier(AccessibilityID.Login.phoneField)
             }
             .padding(12)
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
@@ -103,6 +105,7 @@ struct LoginView: View {
             PrimaryButton("Send OTP", icon: "arrow.right", isLoading: viewModel.isLoading) {
                 Task { await viewModel.requestOTP() }
             }
+            .accessibilityIdentifier(AccessibilityID.Login.sendOTPButton)
         }
     }
 
@@ -120,10 +123,12 @@ struct LoginView: View {
                 .multilineTextAlignment(.center)
                 .padding(12)
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityIdentifier(AccessibilityID.Login.otpField)
 
             PrimaryButton("Verify", icon: "checkmark", isLoading: viewModel.isLoading) {
                 Task { await viewModel.verifyOTP() }
             }
+            .accessibilityIdentifier(AccessibilityID.Login.verifyButton)
 
             Button("Change number") {
                 viewModel.resetOTP()

--- a/AarogyaiOS/Presentation/Reports/ReportsListView.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportsListView.swift
@@ -11,6 +11,7 @@ struct ReportsListView: View {
             GlassFAB(icon: "plus") {
                 showUpload = true
             }
+            .accessibilityIdentifier(AccessibilityID.Reports.fab)
             .padding(24)
         }
         .navigationTitle("Reports")

--- a/AarogyaiOS/Presentation/Settings/ProfileEditView.swift
+++ b/AarogyaiOS/Presentation/Settings/ProfileEditView.swift
@@ -27,8 +27,10 @@ struct ProfileEditView: View {
             Section("Personal Information") {
                 TextField("First Name", text: $viewModel.firstName)
                     .textContentType(.givenName)
+                    .accessibilityIdentifier(AccessibilityID.Profile.firstNameField)
                 TextField("Last Name", text: $viewModel.lastName)
                     .textContentType(.familyName)
+                    .accessibilityIdentifier(AccessibilityID.Profile.lastNameField)
                 TextField("Email", text: $viewModel.email)
                     .textContentType(.emailAddress)
                     .keyboardType(.emailAddress)
@@ -76,6 +78,7 @@ struct ProfileEditView: View {
                 Button("Save Changes") {
                     Task { await viewModel.saveProfile() }
                 }
+                .accessibilityIdentifier(AccessibilityID.Profile.saveButton)
                 .disabled(!viewModel.hasChanges || viewModel.isSaving)
                 .frame(maxWidth: .infinity, alignment: .center)
             }

--- a/AarogyaiOS/Presentation/Settings/SettingsView.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsView.swift
@@ -9,12 +9,15 @@ struct SettingsView: View {
                 NavigationLink(value: SettingsRoute.profile) {
                     Label("Profile", systemImage: "person")
                 }
+                .accessibilityIdentifier(AccessibilityID.Settings.profileRow)
                 NavigationLink(value: SettingsRoute.consents) {
                     Label("Privacy & Consents", systemImage: "hand.raised")
                 }
+                .accessibilityIdentifier(AccessibilityID.Settings.consentsRow)
                 NavigationLink(value: SettingsRoute.notifications) {
                     Label("Notifications", systemImage: "bell")
                 }
+                .accessibilityIdentifier(AccessibilityID.Settings.notificationsRow)
             }
 
             Section("Data") {
@@ -32,12 +35,14 @@ struct SettingsView: View {
                 } label: {
                     Label("Delete Account", systemImage: "trash")
                 }
+                .accessibilityIdentifier(AccessibilityID.Settings.deleteAccountButton)
             }
 
             Section {
                 Button("Sign Out", role: .destructive) {
                     Task { await viewModel.signOut() }
                 }
+                .accessibilityIdentifier(AccessibilityID.Settings.signOutButton)
             }
 
             Section {

--- a/AarogyaiOS/Utilities/AccessibilityID.swift
+++ b/AarogyaiOS/Utilities/AccessibilityID.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+enum AccessibilityID {
+    // MARK: - Login
+    enum Login {
+        static let phoneField = "login.phone.field"
+        static let sendOTPButton = "login.sendOTP.button"
+        static let otpField = "login.otp.field"
+        static let verifyButton = "login.verify.button"
+        static let changeNumberButton = "login.changeNumber.button"
+        static let appleButton = "login.apple.button"
+        static let googleButton = "login.google.button"
+        static let title = "login.title"
+    }
+
+    // MARK: - Tab Bar
+    enum Tab {
+        static let reports = "tab.reports"
+        static let access = "tab.access"
+        static let emergency = "tab.emergency"
+        static let settings = "tab.settings"
+    }
+
+    // MARK: - Reports
+    enum Reports {
+        static let list = "reports.list"
+        static let fab = "reports.fab"
+        static let emptyState = "reports.emptyState"
+        static let searchField = "reports.search"
+        static func card(_ id: String) -> String { "reports.card.\(id)" }
+        static func filterButton(_ type: String) -> String { "reports.filter.\(type)" }
+    }
+
+    // MARK: - Report Detail
+    enum ReportDetail {
+        static let title = "reportDetail.title"
+        static let status = "reportDetail.status"
+        static let doctorName = "reportDetail.doctor"
+        static let labName = "reportDetail.lab"
+    }
+
+    // MARK: - Access Grants
+    enum AccessGrants {
+        static let emptyState = "accessGrants.emptyState"
+        static let addButton = "accessGrants.add.button"
+        static let grantedSection = "accessGrants.granted"
+        static let receivedSection = "accessGrants.received"
+        static func revokeButton(_ id: String) -> String { "accessGrants.revoke.\(id)" }
+    }
+
+    // MARK: - Emergency Contacts
+    enum Emergency {
+        static let emptyState = "emergency.emptyState"
+        static let addButton = "emergency.add.button"
+        static let countLabel = "emergency.count"
+        static func contactRow(_ id: String) -> String { "emergency.contact.\(id)" }
+    }
+
+    // MARK: - Settings
+    enum Settings {
+        static let profileRow = "settings.profile"
+        static let consentsRow = "settings.consents"
+        static let notificationsRow = "settings.notifications"
+        static let exportButton = "settings.export"
+        static let deleteAccountButton = "settings.deleteAccount"
+        static let signOutButton = "settings.signOut"
+        static let versionLabel = "settings.version"
+    }
+
+    // MARK: - Profile Edit
+    enum Profile {
+        static let firstNameField = "profile.firstName"
+        static let lastNameField = "profile.lastName"
+        static let emailField = "profile.email"
+        static let phoneField = "profile.phone"
+        static let saveButton = "profile.save"
+    }
+
+    // MARK: - Consents
+    enum Consents {
+        static func toggle(_ purpose: String) -> String { "consents.toggle.\(purpose)" }
+    }
+
+    // MARK: - Notification Preferences
+    enum Notifications {
+        static let saveButton = "notifications.save"
+    }
+}

--- a/AarogyaiOSUITests/AarogyaiOSUITests.swift
+++ b/AarogyaiOSUITests/AarogyaiOSUITests.swift
@@ -11,23 +11,621 @@ final class AarogyaiOSUITests: XCTestCase {
         app.launchArguments = ["-ui-testing"]
     }
 
-    func testAppLaunches() throws {
+    // MARK: - Login Screen
+
+    private func launchForLogin() {
+        app.launchArguments = ["-ui-testing-login"]
         app.launch()
+    }
+
+    func testLoginScreenShowsBranding() throws {
+        launchForLogin()
         let title = app.staticTexts["Aarogya"]
-        XCTAssertTrue(title.waitForExistence(timeout: 15))
+        XCTAssertTrue(title.waitForExistence(timeout: 15), "Aarogya title should appear")
+
+        let subtitle = app.staticTexts["Your health records, secured"]
+        XCTAssertTrue(subtitle.exists, "Subtitle should appear")
     }
 
     func testLoginScreenShowsPhoneField() throws {
-        app.launch()
-        let phoneField = app.textFields.firstMatch
-        XCTAssertTrue(phoneField.waitForExistence(timeout: 15))
+        launchForLogin()
+        let phoneField = app.textFields["Phone number"]
+        XCTAssertTrue(phoneField.waitForExistence(timeout: 15), "Phone number field should exist")
     }
 
     func testLoginScreenShowsSocialButtons() throws {
-        app.launch()
-        let continueWithApple = app.buttons.matching(
+        launchForLogin()
+        let appleButton = app.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] 'Apple'")
         ).firstMatch
-        XCTAssertTrue(continueWithApple.waitForExistence(timeout: 15))
+        XCTAssertTrue(appleButton.waitForExistence(timeout: 15), "Apple sign-in button should exist")
+
+        let googleButton = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Google'")
+        ).firstMatch
+        XCTAssertTrue(googleButton.exists, "Google sign-in button should exist")
+    }
+
+    func testOTPFlowShowsVerificationUI() throws {
+        launchForLogin()
+
+        let phoneField = app.textFields["Phone number"]
+        XCTAssertTrue(phoneField.waitForExistence(timeout: 15))
+        phoneField.tap()
+        phoneField.typeText("9876543210")
+
+        let sendOTP = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Send OTP'")
+        ).firstMatch
+        XCTAssertTrue(sendOTP.exists, "Send OTP button should exist")
+        sendOTP.tap()
+
+        // After OTP is sent, the OTP input should appear
+        let otpPrompt = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Enter the 6-digit code'")
+        ).firstMatch
+        XCTAssertTrue(otpPrompt.waitForExistence(timeout: 10), "OTP prompt should appear after sending")
+
+        let changeNumber = app.buttons["Change number"]
+        XCTAssertTrue(changeNumber.exists, "Change number button should exist")
+    }
+
+    func testOTPVerificationNavigatesToMainApp() throws {
+        launchForLogin()
+
+        let phoneField = app.textFields["Phone number"]
+        XCTAssertTrue(phoneField.waitForExistence(timeout: 15))
+        phoneField.tap()
+        phoneField.typeText("9876543210")
+
+        app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Send OTP'")
+        ).firstMatch.tap()
+
+        // Wait for OTP field
+        let otpField = app.textFields["000000"]
+        XCTAssertTrue(otpField.waitForExistence(timeout: 10), "OTP field should appear")
+        otpField.tap()
+        otpField.typeText("123456")
+
+        let verify = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Verify'")
+        ).firstMatch
+        XCTAssertTrue(verify.exists)
+        verify.tap()
+
+        // After successful verification, should navigate to the main tab view
+        let reportsTab = app.buttons["Reports"]
+        XCTAssertTrue(reportsTab.waitForExistence(timeout: 15), "Reports tab should appear after login")
+    }
+
+    // MARK: - Reports Tab
+
+    func testReportsTabShowsReportsList() throws {
+        launchAndLogin()
+
+        // Should show Reports tab by default
+        let navTitle = app.navigationBars["Reports"]
+        XCTAssertTrue(navTitle.waitForExistence(timeout: 15), "Reports navigation title should exist")
+
+        // Reports should load from stubs
+        let cbc = app.staticTexts["Complete Blood Count"]
+        XCTAssertTrue(cbc.waitForExistence(timeout: 10), "CBC report should appear in list")
+
+        let urineReport = app.staticTexts["Urine Analysis"]
+        XCTAssertTrue(urineReport.exists, "Urine Analysis report should appear")
+
+        let xray = app.staticTexts["Chest X-Ray"]
+        XCTAssertTrue(xray.exists, "Chest X-Ray report should appear")
+
+        let ecg = app.staticTexts["ECG Report"]
+        XCTAssertTrue(ecg.exists, "ECG Report should appear")
+    }
+
+    func testReportsShowsLabNames() throws {
+        launchAndLogin()
+
+        let lab = app.staticTexts["Apollo Diagnostics"]
+        XCTAssertTrue(lab.waitForExistence(timeout: 10), "Lab name should appear on report card")
+    }
+
+    func testReportsShowsReportNumbers() throws {
+        launchAndLogin()
+
+        let reportNumber = app.staticTexts["RPT-2025-001"]
+        XCTAssertTrue(reportNumber.waitForExistence(timeout: 10), "Report number should appear on card")
+    }
+
+    func testReportsFABExists() throws {
+        launchAndLogin()
+
+        // Wait for reports to load
+        let cbc = app.staticTexts["Complete Blood Count"]
+        XCTAssertTrue(cbc.waitForExistence(timeout: 10))
+
+        let fab = app.buttons.matching(identifier: "reports.fab").firstMatch
+        XCTAssertTrue(fab.exists, "FAB (plus) button should exist on reports screen")
+    }
+
+    // MARK: - Access Grants Tab
+
+    func testAccessGrantsTabShowsGrants() throws {
+        launchAndLogin()
+
+        // Navigate to Access tab
+        let accessTab = app.buttons["Access"]
+        XCTAssertTrue(accessTab.waitForExistence(timeout: 10))
+        accessTab.tap()
+
+        let navTitle = app.navigationBars["Access Grants"]
+        XCTAssertTrue(navTitle.waitForExistence(timeout: 10), "Access Grants nav title should appear")
+
+        // Granted by you section
+        let grantedSection = app.staticTexts["Granted by You"]
+        XCTAssertTrue(grantedSection.waitForExistence(timeout: 10), "Granted by You section should appear")
+
+        // Doctor name
+        let doctorName = app.staticTexts["Dr. Anil Kumar"]
+        XCTAssertTrue(doctorName.exists, "Doctor name should appear in grants list")
+    }
+
+    func testAccessGrantsShowsReceivedGrants() throws {
+        launchAndLogin()
+
+        let accessTab = app.buttons["Access"]
+        XCTAssertTrue(accessTab.waitForExistence(timeout: 10))
+        accessTab.tap()
+
+        let receivedSection = app.staticTexts["Granted to You"]
+        XCTAssertTrue(receivedSection.waitForExistence(timeout: 10), "Granted to You section should appear")
+    }
+
+    func testAccessGrantsShowsStatusBadges() throws {
+        launchAndLogin()
+
+        let accessTab = app.buttons["Access"]
+        XCTAssertTrue(accessTab.waitForExistence(timeout: 10))
+        accessTab.tap()
+
+        // Active grant badge
+        let activeBadge = app.staticTexts["Active"]
+        XCTAssertTrue(activeBadge.waitForExistence(timeout: 10), "Active status badge should appear")
+
+        // Expired grant badge
+        let expiredBadge = app.staticTexts["Expired"]
+        XCTAssertTrue(expiredBadge.exists, "Expired status badge should appear")
+    }
+
+    func testAccessGrantsShowsRevokeButton() throws {
+        launchAndLogin()
+
+        let accessTab = app.buttons["Access"]
+        XCTAssertTrue(accessTab.waitForExistence(timeout: 10))
+        accessTab.tap()
+
+        let revokeButton = app.buttons["Revoke Access"]
+        XCTAssertTrue(revokeButton.waitForExistence(timeout: 10), "Revoke Access button should appear for active grants")
+    }
+
+    func testAccessGrantsShowsGrantDetails() throws {
+        launchAndLogin()
+
+        let accessTab = app.buttons["Access"]
+        XCTAssertTrue(accessTab.waitForExistence(timeout: 10))
+        accessTab.tap()
+
+        // Check scope display
+        let allReports = app.staticTexts["All Reports"]
+        XCTAssertTrue(allReports.waitForExistence(timeout: 10), "All Reports scope should be visible")
+
+        // Check reason
+        let reason = app.staticTexts["Annual checkup follow-up"]
+        XCTAssertTrue(reason.exists, "Grant reason should be visible")
+    }
+
+    // MARK: - Emergency Contacts Tab
+
+    func testEmergencyContactsTabShowsContacts() throws {
+        launchAndLogin()
+
+        let emergencyTab = app.buttons["Emergency"]
+        XCTAssertTrue(emergencyTab.waitForExistence(timeout: 10))
+        emergencyTab.tap()
+
+        let navTitle = app.navigationBars["Emergency Contacts"]
+        XCTAssertTrue(navTitle.waitForExistence(timeout: 10), "Emergency Contacts nav title should appear")
+
+        let contactName = app.staticTexts["Rahul Sharma"]
+        XCTAssertTrue(contactName.waitForExistence(timeout: 10), "Contact name should appear")
+
+        let secondContact = app.staticTexts["Sunita Sharma"]
+        XCTAssertTrue(secondContact.exists, "Second contact should appear")
+    }
+
+    func testEmergencyContactsShowsPrimaryBadge() throws {
+        launchAndLogin()
+
+        let emergencyTab = app.buttons["Emergency"]
+        XCTAssertTrue(emergencyTab.waitForExistence(timeout: 10))
+        emergencyTab.tap()
+
+        let primary = app.staticTexts["Primary"]
+        XCTAssertTrue(primary.waitForExistence(timeout: 10), "Primary badge should appear for primary contact")
+    }
+
+    func testEmergencyContactsShowsRelationship() throws {
+        launchAndLogin()
+
+        let emergencyTab = app.buttons["Emergency"]
+        XCTAssertTrue(emergencyTab.waitForExistence(timeout: 10))
+        emergencyTab.tap()
+
+        let spouse = app.staticTexts["Spouse"]
+        XCTAssertTrue(spouse.waitForExistence(timeout: 10), "Relationship should appear")
+
+        let parent = app.staticTexts["Parent"]
+        XCTAssertTrue(parent.exists, "Parent relationship should appear")
+    }
+
+    func testEmergencyContactsShowsCount() throws {
+        launchAndLogin()
+
+        let emergencyTab = app.buttons["Emergency"]
+        XCTAssertTrue(emergencyTab.waitForExistence(timeout: 10))
+        emergencyTab.tap()
+
+        let count = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS '2/4 contacts'")
+        ).firstMatch
+        XCTAssertTrue(count.waitForExistence(timeout: 10), "Contact count should appear")
+    }
+
+    func testEmergencyContactsShowsPhoneNumber() throws {
+        launchAndLogin()
+
+        let emergencyTab = app.buttons["Emergency"]
+        XCTAssertTrue(emergencyTab.waitForExistence(timeout: 10))
+        emergencyTab.tap()
+
+        let phone = app.staticTexts["+919876543211"]
+        XCTAssertTrue(phone.waitForExistence(timeout: 10), "Phone number should appear for contact")
+    }
+
+    // MARK: - Settings Tab
+
+    func testSettingsTabShowsAllSections() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        let navTitle = app.navigationBars["Settings"]
+        XCTAssertTrue(navTitle.waitForExistence(timeout: 10), "Settings nav title should appear")
+
+        // Account section
+        let profile = app.staticTexts["Profile"]
+        XCTAssertTrue(profile.exists, "Profile row should appear")
+
+        let consents = app.staticTexts["Privacy & Consents"]
+        XCTAssertTrue(consents.exists, "Privacy & Consents row should appear")
+
+        let notifications = app.staticTexts["Notifications"]
+        XCTAssertTrue(notifications.exists, "Notifications row should appear")
+
+        // Data section
+        let exportData = app.staticTexts["Export My Data"]
+        XCTAssertTrue(exportData.exists, "Export My Data should appear")
+
+        // Danger Zone
+        let deleteAccount = app.staticTexts["Delete Account"]
+        XCTAssertTrue(deleteAccount.exists, "Delete Account should appear")
+
+        // Sign Out
+        let signOut = app.buttons["Sign Out"]
+        XCTAssertTrue(signOut.exists, "Sign Out button should appear")
+
+        // Version
+        let version = app.staticTexts["Aarogya v1.0"]
+        XCTAssertTrue(version.exists, "Version label should appear")
+    }
+
+    func testSettingsNavigatesToProfile() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        // Wait for settings to load
+        let profile = app.staticTexts["Profile"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10))
+        profile.tap()
+
+        // Should navigate to Profile screen
+        let profileNav = app.navigationBars["Profile"]
+        XCTAssertTrue(profileNav.waitForExistence(timeout: 10), "Profile screen should appear")
+
+        // Check form fields are populated
+        let firstNameField = app.textFields.matching(
+            NSPredicate(format: "value CONTAINS 'Priya'")
+        ).firstMatch
+        XCTAssertTrue(firstNameField.waitForExistence(timeout: 10), "First name should be populated")
+
+        let lastNameField = app.textFields.matching(
+            NSPredicate(format: "value CONTAINS 'Sharma'")
+        ).firstMatch
+        XCTAssertTrue(lastNameField.exists, "Last name should be populated")
+    }
+
+    func testSettingsNavigatesToConsents() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        let consents = app.staticTexts["Privacy & Consents"]
+        XCTAssertTrue(consents.waitForExistence(timeout: 10))
+        consents.tap()
+
+        let consentsNav = app.navigationBars["Privacy & Consents"]
+        XCTAssertTrue(consentsNav.waitForExistence(timeout: 10), "Consents screen should appear")
+
+        // DPDPA notice
+        let dpdpaNotice = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] 'DPDPA'")
+        ).firstMatch
+        XCTAssertTrue(dpdpaNotice.waitForExistence(timeout: 10), "DPDPA notice should appear")
+
+        // Consent purposes
+        let profileMgmt = app.staticTexts["Profile Management"]
+        XCTAssertTrue(profileMgmt.exists, "Profile Management consent should appear")
+
+        let medicalRecords = app.staticTexts["Medical Records Processing"]
+        XCTAssertTrue(medicalRecords.exists, "Medical Records Processing consent should appear")
+
+        let dataSharing = app.staticTexts["Medical Data Sharing"]
+        XCTAssertTrue(dataSharing.exists, "Medical Data Sharing consent should appear")
+
+        let emergencyMgmt = app.staticTexts["Emergency Contact Management"]
+        XCTAssertTrue(emergencyMgmt.exists, "Emergency Contact Management consent should appear")
+    }
+
+    func testSettingsNavigatesToNotifications() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        let notifications = app.staticTexts["Notifications"]
+        XCTAssertTrue(notifications.waitForExistence(timeout: 10))
+        notifications.tap()
+
+        let notifNav = app.navigationBars["Notifications"]
+        XCTAssertTrue(notifNav.waitForExistence(timeout: 10), "Notifications screen should appear")
+
+        // Notification categories
+        let reportUploaded = app.staticTexts["Report Uploaded"]
+        XCTAssertTrue(reportUploaded.waitForExistence(timeout: 10), "Report Uploaded section should appear")
+
+        let accessGranted = app.staticTexts["Access Granted"]
+        XCTAssertTrue(accessGranted.exists, "Access Granted section should appear")
+
+        let emergencyAccess = app.staticTexts["Emergency Access"]
+        XCTAssertTrue(emergencyAccess.exists, "Emergency Access section should appear")
+
+        // Channel toggles
+        let pushToggle = app.switches.matching(
+            NSPredicate(format: "label CONTAINS 'Push Notifications'")
+        ).firstMatch
+        XCTAssertTrue(pushToggle.exists, "Push notification toggle should exist")
+
+        let emailToggle = app.switches.matching(
+            NSPredicate(format: "label CONTAINS 'Email'")
+        ).firstMatch
+        XCTAssertTrue(emailToggle.exists, "Email toggle should exist")
+
+        let smsToggle = app.switches.matching(
+            NSPredicate(format: "label CONTAINS 'SMS'")
+        ).firstMatch
+        XCTAssertTrue(smsToggle.exists, "SMS toggle should exist")
+
+        // Save button
+        let saveButton = app.buttons["Save Preferences"]
+        XCTAssertTrue(saveButton.exists, "Save Preferences button should exist")
+    }
+
+    func testSettingsDeleteAccountShowsConfirmation() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        let deleteAccount = app.buttons.matching(identifier: "settings.deleteAccount").firstMatch
+        XCTAssertTrue(deleteAccount.waitForExistence(timeout: 10))
+        deleteAccount.tap()
+
+        // Alert should appear
+        let alert = app.alerts["Delete Account"]
+        XCTAssertTrue(alert.waitForExistence(timeout: 5), "Delete Account confirmation alert should appear")
+
+        let alertMessage = alert.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS 'irreversible'")
+        ).firstMatch
+        XCTAssertTrue(alertMessage.exists, "Warning message should appear in alert")
+
+        // Cancel button
+        let cancel = alert.buttons["Cancel"]
+        XCTAssertTrue(cancel.exists, "Cancel button should exist in alert")
+        cancel.tap()
+
+        // Alert should dismiss
+        XCTAssertFalse(alert.waitForExistence(timeout: 3), "Alert should dismiss after Cancel")
+    }
+
+    func testSignOutReturnsToLogin() throws {
+        launchAndLogin()
+
+        let settingsTab = app.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 10))
+        settingsTab.tap()
+
+        let signOut = app.buttons["Sign Out"]
+        XCTAssertTrue(signOut.waitForExistence(timeout: 10))
+        signOut.tap()
+
+        // Should return to login screen
+        let loginTitle = app.staticTexts["Aarogya"]
+        XCTAssertTrue(loginTitle.waitForExistence(timeout: 15), "Should return to login screen after sign out")
+
+        let phoneField = app.textFields["Phone number"]
+        XCTAssertTrue(phoneField.exists, "Phone field should appear on login screen")
+    }
+
+    // MARK: - Tab Navigation
+
+    func testCanNavigateBetweenAllTabs() throws {
+        launchAndLogin()
+
+        // Start on Reports
+        let reportsNav = app.navigationBars["Reports"]
+        XCTAssertTrue(reportsNav.waitForExistence(timeout: 15))
+
+        // Navigate to Access
+        app.buttons["Access"].tap()
+        let accessNav = app.navigationBars["Access Grants"]
+        XCTAssertTrue(accessNav.waitForExistence(timeout: 10), "Should navigate to Access Grants")
+
+        // Navigate to Emergency
+        app.buttons["Emergency"].tap()
+        let emergencyNav = app.navigationBars["Emergency Contacts"]
+        XCTAssertTrue(emergencyNav.waitForExistence(timeout: 10), "Should navigate to Emergency Contacts")
+
+        // Navigate to Settings
+        app.buttons["Settings"].tap()
+        let settingsNav = app.navigationBars["Settings"]
+        XCTAssertTrue(settingsNav.waitForExistence(timeout: 10), "Should navigate to Settings")
+
+        // Back to Reports
+        app.buttons["Reports"].tap()
+        XCTAssertTrue(reportsNav.waitForExistence(timeout: 10), "Should navigate back to Reports")
+    }
+
+    // MARK: - Profile Edit Flow
+
+    func testProfileShowsUserData() throws {
+        launchAndLogin()
+
+        app.buttons["Settings"].tap()
+        let profile = app.staticTexts["Profile"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10))
+        profile.tap()
+
+        let profileNav = app.navigationBars["Profile"]
+        XCTAssertTrue(profileNav.waitForExistence(timeout: 10))
+
+        // Email should be displayed (disabled)
+        let emailField = app.textFields.matching(
+            NSPredicate(format: "value CONTAINS 'priya.sharma@example.com'")
+        ).firstMatch
+        XCTAssertTrue(emailField.waitForExistence(timeout: 10), "Email should be populated")
+
+        // Phone should be displayed (disabled)
+        let phoneField = app.textFields.matching(
+            NSPredicate(format: "value CONTAINS '+919876543210'")
+        ).firstMatch
+        XCTAssertTrue(phoneField.exists, "Phone should be populated")
+    }
+
+    func testProfileShowsHealthInfo() throws {
+        launchAndLogin()
+
+        app.buttons["Settings"].tap()
+        let profile = app.staticTexts["Profile"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10))
+        profile.tap()
+
+        let profileNav = app.navigationBars["Profile"]
+        XCTAssertTrue(profileNav.waitForExistence(timeout: 10))
+
+        // Health Information section
+        let healthSection = app.staticTexts["Health Information"]
+        XCTAssertTrue(healthSection.waitForExistence(timeout: 10), "Health Information section should exist")
+
+        // Blood Group picker
+        let bloodGroup = app.staticTexts["Blood Group"]
+        XCTAssertTrue(bloodGroup.exists, "Blood Group picker should exist")
+
+        // Gender picker
+        let gender = app.staticTexts["Gender"]
+        XCTAssertTrue(gender.exists, "Gender picker should exist")
+
+        // Save button should exist
+        let saveButton = app.buttons["Save Changes"]
+        XCTAssertTrue(saveButton.exists, "Save Changes button should exist")
+    }
+
+    // MARK: - Consents Details
+
+    func testConsentsShowsRequiredLabel() throws {
+        launchAndLogin()
+
+        app.buttons["Settings"].tap()
+        let consents = app.staticTexts["Privacy & Consents"]
+        XCTAssertTrue(consents.waitForExistence(timeout: 10))
+        consents.tap()
+
+        let requiredLabel = app.staticTexts["Required for core functionality"]
+        XCTAssertTrue(requiredLabel.waitForExistence(timeout: 10), "Required label should appear for required consents")
+    }
+
+    func testConsentsShowsDescriptions() throws {
+        launchAndLogin()
+
+        app.buttons["Settings"].tap()
+        let consents = app.staticTexts["Privacy & Consents"]
+        XCTAssertTrue(consents.waitForExistence(timeout: 10))
+        consents.tap()
+
+        let description = app.staticTexts["Allow processing of your profile data"]
+        XCTAssertTrue(description.waitForExistence(timeout: 10), "Consent description should appear")
+    }
+
+    // MARK: - Helper Methods
+
+    private func launchAndLogin() {
+        app.launch()
+
+        // In UI testing mode with stub repos, the app detects the pre-loaded
+        // token and auto-authenticates. Wait for the tab bar to appear.
+        let reportsTab = app.buttons["Reports"]
+        if reportsTab.waitForExistence(timeout: 5) {
+            return // Already authenticated
+        }
+
+        // If still on login, perform OTP flow
+        let phoneField = app.textFields["Phone number"]
+        guard phoneField.waitForExistence(timeout: 10) else { return }
+        phoneField.tap()
+        phoneField.typeText("9876543210")
+
+        app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Send OTP'")
+        ).firstMatch.tap()
+
+        let otpField = app.textFields["000000"]
+        guard otpField.waitForExistence(timeout: 10) else { return }
+        otpField.tap()
+        otpField.typeText("123456")
+
+        app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'Verify'")
+        ).firstMatch.tap()
+
+        // Wait for main app to load
+        let _ = app.buttons["Reports"].waitForExistence(timeout: 15)
     }
 }


### PR DESCRIPTION
## Summary

- Add **30 E2E UI tests** (up from 3) covering every app flow: login/OTP, reports list, access grants, emergency contacts, settings, profile edit, consents, notifications, tab navigation, and sign-out
- Introduce **UI testing mock mode** via `-ui-testing` / `-ui-testing-login` launch arguments that inject stub repositories through `DependencyContainer`, enabling full simulator testing without a live backend
- Add `UITestingStubs.swift` with stub implementations of all 7 repositories, token store, and file uploader — populated with realistic Indian healthcare test data
- Add `AccessibilityID.swift` with centralized accessibility identifier constants
- Refactor `DependencyContainer` using a `DependencyBundle` pattern to cleanly support both production and stub dependency injection
- Add accessibility identifiers to Login, Settings, Profile, and Reports views

## Test plan

- [x] All 30 UI tests pass on iPhone 17 Pro Max simulator (`xcodebuild test -only-testing:AarogyaiOSUITests`)
- [x] All existing unit tests pass with no regressions (`xcodebuild test -only-testing:AarogyaiOSTests`)
- [x] Production code path unchanged — stubs only activate with `-ui-testing` launch arg
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)