### PR TITLE
feat(auth): implement social login with Apple and Google via PKCE

### DIFF
--- a/AarogyaiOS/App/UITestingStubs.swift
+++ b/AarogyaiOS/App/UITestingStubs.swift
@@ -62,8 +62,12 @@ final class StubAuthRepository: AuthRepository, @unchecked Sendable {
         self.tokenStore = tokenStore
     }
 
-    func socialAuthorize(provider: String) async throws -> URL {
-        URL(string: "https://auth.example.com")!
+    func socialAuthorize(provider: String) async throws -> SocialAuthSession {
+        SocialAuthSession(
+            authorizeURL: URL(string: "https://auth.example.com")!,
+            codeVerifier: "stub-verifier",
+            state: "stub-state"
+        )
     }
 
     func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {

--- a/AarogyaiOS/Data/Repositories/DefaultAuthRepository.swift
+++ b/AarogyaiOS/Data/Repositories/DefaultAuthRepository.swift
@@ -10,9 +10,11 @@ struct DefaultAuthRepository: AuthRepository {
         self.tokenStore = tokenStore
     }
 
-    func socialAuthorize(provider: String) async throws -> URL {
+    func socialAuthorize(provider: String) async throws -> SocialAuthSession {
         let codeVerifier = PKCEGenerator.generateCodeVerifier()
-        let codeChallenge = PKCEGenerator.generateCodeChallenge(from: codeVerifier)
+        let codeChallenge = PKCEGenerator.generateCodeChallenge(
+            from: codeVerifier
+        )
         let state = PKCEGenerator.generateState()
 
         let request = SocialAuthorizeRequest(
@@ -31,7 +33,12 @@ struct DefaultAuthRepository: AuthRepository {
         guard let url = URL(string: response.authorizeUrl) else {
             throw APIError.decodingError(underlying: URLError(.badURL))
         }
-        return url
+
+        return SocialAuthSession(
+            authorizeURL: url,
+            codeVerifier: codeVerifier,
+            state: state
+        )
     }
 
     func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {

--- a/AarogyaiOS/Domain/Repositories/AuthRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/AuthRepository.swift
@@ -1,7 +1,13 @@
 import Foundation
 
+struct SocialAuthSession: Sendable {
+    let authorizeURL: URL
+    let codeVerifier: String
+    let state: String
+}
+
 protocol AuthRepository: Sendable {
-    func socialAuthorize(provider: String) async throws -> URL
+    func socialAuthorize(provider: String) async throws -> SocialAuthSession
     func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens
     func requestOTP(phone: String) async throws
     func verifyOTP(phone: String, otp: String) async throws -> AuthTokens

--- a/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
@@ -25,7 +25,7 @@ struct LoginUseCase: Sendable {
         try await authRepository.requestOTP(phone: phone)
     }
 
-    func getAuthorizeURL(provider: String) async throws -> URL {
+    func getAuthSession(provider: String) async throws -> SocialAuthSession {
         try await authRepository.socialAuthorize(provider: provider)
     }
 }

--- a/AarogyaiOS/Presentation/Auth/LoginView.swift
+++ b/AarogyaiOS/Presentation/Auth/LoginView.swift
@@ -46,11 +46,13 @@ struct LoginView: View {
     private var socialLoginButtons: some View {
         VStack(spacing: 12) {
             SocialLoginButton(provider: .apple) {
-                // Social login handled in future iteration
+                Task { await viewModel.loginWithSocial(provider: .apple) }
             }
+            .disabled(viewModel.isLoading)
             SocialLoginButton(provider: .google) {
-                // Social login handled in future iteration
+                Task { await viewModel.loginWithSocial(provider: .google) }
             }
+            .disabled(viewModel.isLoading)
         }
     }
 

--- a/AarogyaiOS/Presentation/Auth/LoginViewModel.swift
+++ b/AarogyaiOS/Presentation/Auth/LoginViewModel.swift
@@ -19,6 +19,8 @@ final class LoginViewModel {
         self.onLoginSuccess = onLoginSuccess
     }
 
+    // MARK: - OTP Flow
+
     func requestOTP() async {
         guard !phone.isEmpty else {
             error = "Please enter your phone number"
@@ -69,6 +71,108 @@ final class LoginViewModel {
         otpSent = false
         otp = ""
         error = nil
+    }
+
+    // MARK: - Social Login
+
+    func loginWithSocial(provider: SocialLoginButton.SocialProvider) async {
+        isLoading = true
+        error = nil
+
+        let providerName: String = switch provider {
+        case .apple: "Apple"
+        case .google: "Google"
+        }
+
+        do {
+            let session = try await loginUseCase.getAuthSession(
+                provider: providerName
+            )
+            let callbackURL = try await performWebAuth(
+                url: session.authorizeURL,
+                state: session.state
+            )
+            let code = try extractAuthCode(from: callbackURL, expectedState: session.state)
+            _ = try await loginUseCase.executeSocial(
+                provider: providerName,
+                code: code,
+                codeVerifier: session.codeVerifier
+            )
+            await onLoginSuccess()
+        } catch is CancellationError {
+            Logger.auth.info("Social login cancelled by user")
+        } catch ASWebAuthenticationSessionError.canceledLogin {
+            Logger.auth.info("Social login cancelled by user")
+        } catch let apiError as APIError {
+            error = errorMessage(for: apiError)
+        } catch {
+            self.error = "Sign in failed. Please try again."
+            Logger.auth.error("Social login failed: \(error)")
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Private
+
+    private func performWebAuth(url: URL, state: String) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let webSession = ASWebAuthenticationSession(
+                url: url,
+                callback: .customScheme("aarogya")
+            ) { callbackURL, sessionError in
+                if let sessionError {
+                    continuation.resume(throwing: sessionError)
+                } else if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(
+                        throwing: ASWebAuthenticationSessionError(
+                            .canceledLogin
+                        )
+                    )
+                }
+            }
+            webSession.prefersEphemeralWebBrowserSession = false
+            webSession.start()
+        }
+    }
+
+    private func extractAuthCode(
+        from url: URL,
+        expectedState: String
+    ) throws -> String {
+        guard let components = URLComponents(
+            url: url, resolvingAgainstBaseURL: false
+        ) else {
+            throw APIError.decodingError(underlying: URLError(.badURL))
+        }
+
+        let queryItems = components.queryItems ?? []
+
+        if let errorParam = queryItems.first(where: { $0.name == "error" })?.value {
+            let description = queryItems
+                .first { $0.name == "error_description" }?.value
+                ?? errorParam
+            Logger.auth.error("OAuth error: \(description)")
+            throw APIError.validationError(
+                fields: [FieldError(field: "oauth", message: description)]
+            )
+        }
+
+        guard let code = queryItems.first(where: { $0.name == "code" })?.value else {
+            throw APIError.decodingError(underlying: URLError(.badURL))
+        }
+
+        if let state = queryItems.first(where: { $0.name == "state" })?.value,
+           state != expectedState {
+            Logger.auth.error("OAuth state mismatch")
+            throw APIError.validationError(
+                fields: [FieldError(field: "state", message: "State mismatch")]
+            )
+        }
+
+        return code
     }
 
     private func errorMessage(for error: APIError) -> String {

--- a/AarogyaiOSTests/Domain/LoginUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/LoginUseCaseTests.swift
@@ -39,8 +39,10 @@ struct LoginUseCaseTests {
         #expect(user.id == "user-1")
     }
 
-    @Test func getAuthorizeURLReturnsURL() async throws {
-        let url = try await sut.getAuthorizeURL(provider: "google")
-        #expect(url.absoluteString == "https://auth.example.com")
+    @Test func getAuthSessionReturnsSession() async throws {
+        let session = try await sut.getAuthSession(provider: "google")
+        #expect(session.authorizeURL.absoluteString == "https://auth.example.com")
+        #expect(session.codeVerifier == "test-verifier")
+        #expect(session.state == "test-state")
     }
 }

--- a/AarogyaiOSTests/Mocks/MockAuthRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockAuthRepository.swift
@@ -2,7 +2,9 @@ import Foundation
 @testable import AarogyaiOS
 
 final class MockAuthRepository: AuthRepository, @unchecked Sendable {
-    var socialAuthorizeResult: Result<URL, Error> = .success(URL(string: "https://auth.example.com")!)
+    var socialAuthorizeResult: Result<SocialAuthSession, Error> = .success(
+        SocialAuthSession(authorizeURL: URL(string: "https://auth.example.com")!, codeVerifier: "test-verifier", state: "test-state")
+    )
     var socialTokenResult: Result<AuthTokens, Error> = .success(.stub)
     var requestOTPResult: Result<Void, Error> = .success(())
     var verifyOTPResult: Result<AuthTokens, Error> = .success(.stub)
@@ -22,7 +24,7 @@ final class MockAuthRepository: AuthRepository, @unchecked Sendable {
     var lastVerifiedPhone: String?
     var lastVerifiedOTP: String?
 
-    func socialAuthorize(provider: String) async throws -> URL {
+    func socialAuthorize(provider: String) async throws -> SocialAuthSession {
         socialAuthorizeCallCount += 1
         return try socialAuthorizeResult.get()
     }

--- a/AarogyaiOSUITests/AarogyaiOSUITests.swift
+++ b/AarogyaiOSUITests/AarogyaiOSUITests.swift
@@ -432,9 +432,12 @@ final class AarogyaiOSUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(smsToggle.exists, "SMS toggle should exist")
 
-        // Save button
+        // Save button (may need scrolling into view)
         let saveButton = app.buttons["Save Preferences"]
-        XCTAssertTrue(saveButton.exists, "Save Preferences button should exist")
+        if !saveButton.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save Preferences button should exist")
     }
 
     func testSettingsDeleteAccountShowsConfirmation() throws {


### PR DESCRIPTION
## Summary
- Wire up Continue with Apple / Continue with Google buttons to full OAuth PKCE flow using `ASWebAuthenticationSession`
- Introduce `SocialAuthSession` struct to return authorize URL + codeVerifier + state together, fixing a bug where the PKCE code verifier was lost between the authorize and token exchange steps
- Fix flaky `testSettingsNavigatesToNotifications` UI test by scrolling to the Save Preferences button

## Changes
- **`AuthRepository.swift`** — Add `SocialAuthSession` struct, update `socialAuthorize()` return type
- **`DefaultAuthRepository.swift`** — Return `SocialAuthSession` preserving codeVerifier and state
- **`LoginUseCase.swift`** — Rename `getAuthorizeURL()` → `getAuthSession()` returning full session
- **`LoginViewModel.swift`** — Add `loginWithSocial(provider:)` with `ASWebAuthenticationSession`, OAuth callback parsing, and state validation
- **`LoginView.swift`** — Wire social buttons to `viewModel.loginWithSocial()`, disable during loading
- **`UITestingStubs.swift`** / **`MockAuthRepository.swift`** / **`LoginUseCaseTests.swift`** — Update for new `SocialAuthSession` type
- **`AarogyaiOSUITests.swift`** — Fix flaky notification preferences test

## Test plan
- [x] 78 unit tests pass (0 failures)
- [x] All UI tests pass including previously-flaky notification test
- [x] SwiftLint clean (no new violations)
- [ ] Manual: tap Continue with Google → Cognito hosted UI opens → callback returns tokens
- [ ] Manual: tap Continue with Apple → Cognito hosted UI opens → callback returns tokens
- [ ] Manual: cancel social login → no error shown, buttons re-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)