### PR TITLE
fix(auth): correct JSON casing for social auth API requests

### DIFF
--- a/AarogyaiOS/App/UITestingStubs.swift
+++ b/AarogyaiOS/App/UITestingStubs.swift
@@ -70,7 +70,7 @@ final class StubAuthRepository: AuthRepository, @unchecked Sendable {
         )
     }
 
-    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {
+    func socialToken(provider: String, code: String, codeVerifier: String) async throws -> AuthTokens {
         AuthTokens(accessToken: "stub-access", refreshToken: "stub-refresh", idToken: "stub-id", expiresIn: 3600)
     }
 

--- a/AarogyaiOS/Data/Network/DTOs/Auth/SocialAuthDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Auth/SocialAuthDTO.swift
@@ -1,22 +1,47 @@
 import Foundation
 
+// MARK: - Social Auth DTOs
+// Backend uses camelCase JSON keys; explicit CodingKeys override the
+// global snake_case encoder/decoder strategy used by APIClient.
+
 struct SocialAuthorizeRequest: Encodable, Sendable {
     let provider: String
     let codeChallenge: String
     let codeChallengeMethod: String
     let state: String
     let redirectUri: String
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case codeChallenge
+        case codeChallengeMethod
+        case state
+        case redirectUri
+    }
 }
 
 struct SocialAuthorizeResponse: Decodable, Sendable {
     let authorizeUrl: String
+    let state: String
+
+    enum CodingKeys: String, CodingKey {
+        case authorizeUrl
+        case state
+    }
 }
 
 struct SocialTokenRequest: Encodable, Sendable {
+    let provider: String
     let code: String
     let codeVerifier: String
-    let state: String
     let redirectUri: String
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case code = "authorizationCode"
+        case codeVerifier
+        case redirectUri
+    }
 }
 
 struct TokenResponse: Decodable, Sendable {
@@ -25,4 +50,12 @@ struct TokenResponse: Decodable, Sendable {
     let idToken: String
     let expiresIn: Int
     let tokenType: String
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken
+        case refreshToken
+        case idToken
+        case expiresIn
+        case tokenType
+    }
 }

--- a/AarogyaiOS/Data/Repositories/DefaultAuthRepository.swift
+++ b/AarogyaiOS/Data/Repositories/DefaultAuthRepository.swift
@@ -41,11 +41,11 @@ struct DefaultAuthRepository: AuthRepository {
         )
     }
 
-    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {
+    func socialToken(provider: String, code: String, codeVerifier: String) async throws -> AuthTokens {
         let request = SocialTokenRequest(
+            provider: provider,
             code: code,
             codeVerifier: codeVerifier,
-            state: "",
             redirectUri: "aarogya://auth/callback"
         )
         let response: TokenResponse = try await apiClient.request(.socialToken, body: request)

--- a/AarogyaiOS/Domain/Repositories/AuthRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/AuthRepository.swift
@@ -8,7 +8,7 @@ struct SocialAuthSession: Sendable {
 
 protocol AuthRepository: Sendable {
     func socialAuthorize(provider: String) async throws -> SocialAuthSession
-    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens
+    func socialToken(provider: String, code: String, codeVerifier: String) async throws -> AuthTokens
     func requestOTP(phone: String) async throws
     func verifyOTP(phone: String, otp: String) async throws -> AuthTokens
     func refreshToken(refreshToken: String) async throws -> AuthTokens

--- a/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Auth/LoginUseCase.swift
@@ -10,7 +10,7 @@ struct LoginUseCase: Sendable {
     }
 
     func executeSocial(provider: String, code: String, codeVerifier: String) async throws -> User {
-        let tokens = try await authRepository.socialToken(code: code, codeVerifier: codeVerifier)
+        let tokens = try await authRepository.socialToken(provider: provider, code: code, codeVerifier: codeVerifier)
         try await tokenStore.store(tokens)
         return try await authRepository.getCurrentUser()
     }

--- a/AarogyaiOSTests/Mocks/MockAuthRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockAuthRepository.swift
@@ -29,7 +29,7 @@ final class MockAuthRepository: AuthRepository, @unchecked Sendable {
         return try socialAuthorizeResult.get()
     }
 
-    func socialToken(code: String, codeVerifier: String) async throws -> AuthTokens {
+    func socialToken(provider: String, code: String, codeVerifier: String) async throws -> AuthTokens {
         socialTokenCallCount += 1
         return try socialTokenResult.get()
     }


### PR DESCRIPTION
## Summary
- Add explicit `CodingKeys` to all social auth DTOs (`SocialAuthorizeRequest`, `SocialAuthorizeResponse`, `SocialTokenRequest`, `TokenResponse`) to send camelCase keys instead of the global snake_case encoder default
- Align `SocialTokenRequest` with backend's `SocialTokenCommand` contract: add `provider` field, map `code` → `authorizationCode`
- Thread `provider` parameter through `AuthRepository.socialToken()` and `LoginUseCase.executeSocial()`

## Root cause
The `APIClient` uses `keyEncodingStrategy = .convertToSnakeCase` globally. Social auth DTOs were sending `redirect_uri`, `code_challenge`, etc. but the ASP.NET backend expects camelCase (`redirectUri`, `codeChallenge`). This caused `RedirectUri` to deserialize as `null` on the backend, triggering a `NullReferenceException`.

## Test plan
- [x] 78 unit tests pass (0 failures)
- [x] Build succeeds
- [ ] Manual: social login flow sends correct camelCase JSON to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)