### PR TITLE
feat(ui): add smooth launch-to-login transition and staggered animations

### DIFF
--- a/AarogyaiOS/App/AarogyaApp.swift
+++ b/AarogyaiOS/App/AarogyaApp.swift
@@ -16,6 +16,8 @@ struct AarogyaApp: App {
 struct RootView: View {
     let container: DependencyContainer
     @State private var coordinator: AppCoordinator
+    @State private var showLaunchScreen = true
+    @State private var showContent = false
 
     init(container: DependencyContainer) {
         self.container = container
@@ -23,57 +25,83 @@ struct RootView: View {
     }
 
     var body: some View {
-        Group {
-            switch coordinator.state {
-            case .loading:
+        ZStack {
+            // Shared background — always visible behind both layers
+            SereneBloomBackground()
+
+            // Content layer — appears after launch screen fades out
+            if showContent {
+                contentView
+            }
+
+            // Launch screen overlay — plays bloom then fades out
+            if showLaunchScreen {
                 LaunchScreen()
-            case .unauthenticated:
-                LoginView(viewModel: LoginViewModel(
-                    loginUseCase: container.loginUseCase,
-                    onLoginSuccess: {
-                        await coordinator.handleLogin()
-                        coordinator.consumePendingDeepLink()
-                    }
-                ))
-            case .registration:
-                RegisterView(viewModel: RegisterViewModel(
-                    registerUseCase: container.registerUserUseCase,
-                    onRegistrationComplete: {
-                        await coordinator.handleRegistrationComplete()
-                    }
-                ))
-            case .pendingApproval:
-                PendingApprovalView(
-                    checkStatusUseCase: container.checkRegistrationStatusUseCase,
-                    onStatusChange: { _ in
-                        Task { await coordinator.handleRegistrationComplete() }
-                    },
-                    onSignOut: {
-                        Task { await coordinator.handleLogout() }
-                    }
-                )
-            case .rejected:
-                RejectedRegistrationView(
-                    reason: nil,
-                    onSignOut: {
-                        Task { await coordinator.handleLogout() }
-                    }
-                )
-            case .authenticated:
-                TabCoordinator(
-                    container: container,
-                    selectedTab: $coordinator.selectedTab,
-                    onSignOut: { await coordinator.handleLogout() }
-                )
+                    .transition(.opacity)
             }
         }
+        .animation(.easeOut(duration: 0.7), value: showLaunchScreen)
         .environment(coordinator)
         .onOpenURL { url in
             coordinator.handleURL(url)
         }
         .task {
-            await coordinator.checkAuthState()
+            // Run auth check and minimum 2s display in parallel
+            async let auth: Void = coordinator.checkAuthState()
+            async let delay: Void = Task.sleep(for: .seconds(2))
+            _ = await (try? auth, try? delay)
+
+            // Fade out launch screen
+            showLaunchScreen = false
+
+            // Wait for fade to nearly complete, then reveal content
+            try? await Task.sleep(for: .milliseconds(500))
+            showContent = true
             coordinator.consumePendingDeepLink()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch coordinator.state {
+        case .loading, .unauthenticated:
+            LoginView(viewModel: LoginViewModel(
+                loginUseCase: container.loginUseCase,
+                onLoginSuccess: {
+                    await coordinator.handleLogin()
+                    coordinator.consumePendingDeepLink()
+                }
+            ))
+        case .registration:
+            RegisterView(viewModel: RegisterViewModel(
+                registerUseCase: container.registerUserUseCase,
+                onRegistrationComplete: {
+                    await coordinator.handleRegistrationComplete()
+                }
+            ))
+        case .pendingApproval:
+            PendingApprovalView(
+                checkStatusUseCase: container.checkRegistrationStatusUseCase,
+                onStatusChange: { _ in
+                    Task { await coordinator.handleRegistrationComplete() }
+                },
+                onSignOut: {
+                    Task { await coordinator.handleLogout() }
+                }
+            )
+        case .rejected:
+            RejectedRegistrationView(
+                reason: nil,
+                onSignOut: {
+                    Task { await coordinator.handleLogout() }
+                }
+            )
+        case .authenticated:
+            TabCoordinator(
+                container: container,
+                selectedTab: $coordinator.selectedTab,
+                onSignOut: { await coordinator.handleLogout() }
+            )
         }
     }
 }

--- a/AarogyaiOS/Presentation/Auth/LoginView.swift
+++ b/AarogyaiOS/Presentation/Auth/LoginView.swift
@@ -2,25 +2,59 @@ import SwiftUI
 
 struct LoginView: View {
     @State var viewModel: LoginViewModel
+    @State private var showBranding = false
+    @State private var showSocialButtons = false
+    @State private var showDivider = false
+    @State private var showPhoneSection = false
+    @State private var showFooter = false
 
     var body: some View {
         VStack(spacing: 32) {
             Spacer()
 
             branding
+                .opacity(showBranding ? 1 : 0)
+                .scaleEffect(showBranding ? 1 : 0.8)
 
             socialLoginButtons
+                .opacity(showSocialButtons ? 1 : 0)
+                .offset(y: showSocialButtons ? 0 : 24)
 
             divider
+                .opacity(showDivider ? 1 : 0)
 
             phoneLoginSection
+                .opacity(showPhoneSection ? 1 : 0)
+                .offset(y: showPhoneSection ? 0 : 20)
 
             Spacer()
 
             termsFooter
+                .opacity(showFooter ? 1 : 0)
         }
         .padding(24)
         .sereneBloomBackground()
+        .task {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.8)) {
+                showBranding = true
+            }
+            try? await Task.sleep(for: .milliseconds(200))
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                showSocialButtons = true
+            }
+            try? await Task.sleep(for: .milliseconds(150))
+            withAnimation(.easeOut(duration: 0.4)) {
+                showDivider = true
+            }
+            try? await Task.sleep(for: .milliseconds(150))
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                showPhoneSection = true
+            }
+            try? await Task.sleep(for: .milliseconds(200))
+            withAnimation(.easeOut(duration: 0.5)) {
+                showFooter = true
+            }
+        }
     }
 
     // MARK: - Branding
@@ -63,8 +97,16 @@ struct LoginView: View {
         VStack(spacing: 16) {
             if viewModel.otpSent {
                 otpInput
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    ))
             } else {
                 phoneInput
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .leading).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    ))
             }
 
             if let error = viewModel.error {
@@ -72,8 +114,11 @@ struct LoginView: View {
                     .font(Typography.caption)
                     .foregroundStyle(Color.Fallback.statusCritical)
                     .multilineTextAlignment(.center)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
             }
         }
+        .animation(.spring(response: 0.5, dampingFraction: 0.85), value: viewModel.otpSent)
+        .animation(.easeOut(duration: 0.3), value: viewModel.error)
     }
 
     private var phoneInput: some View {


### PR DESCRIPTION
## Summary

- **2-second launch screen**: Bloom animation (Shield Tree logo, ripple rings, wordmark) plays for a minimum of 2 seconds while auth check runs in parallel
- **Clean two-phase transition**: Launch screen fades out (0.7s) into the shared Serene Bloom background, then content is revealed — no ghosting or double-rendering
- **Staggered login entrance**: Logo springs in → social buttons slide up → divider fades → phone section slides up → footer fades (total ~0.7s cascade)
- **OTP slide transition**: Phone input slides left while OTP input slides in from right with spring animation
- **Error animation**: Error messages appear with scale + opacity transition

## Test plan

- [x] All unit tests pass
- [x] Build succeeds
- [ ] Cold launch shows bloom animation for full 2 seconds
- [ ] Launch screen fades cleanly without ghosting
- [ ] Login elements stagger in sequentially after fade
- [ ] Light and dark mode transitions both look smooth
- [ ] OTP state change animates with slide transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)