### PR TITLE
feat(emergency-contacts): add delete confirmation dialog

### DIFF
--- a/AarogyaiOS/Presentation/Emergency/EmergencyContactsView.swift
+++ b/AarogyaiOS/Presentation/Emergency/EmergencyContactsView.swift
@@ -34,6 +34,26 @@ struct EmergencyContactsView: View {
         }
         .refreshable { await viewModel.loadContacts() }
         .task { await viewModel.loadContacts() }
+        .confirmationDialog(
+            "Delete Contact",
+            isPresented: $viewModel.showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.deleteContact() }
+            }
+        } message: {
+            if let contact = viewModel.contactToDelete {
+                Text("Remove \(contact.name) from your emergency contacts? This action cannot be undone.")
+            }
+        }
+        .alert("Error", isPresented: $viewModel.showError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
         .sheet(isPresented: $viewModel.showContactForm) {
             Task { await viewModel.onContactSaved() }
         } content: {
@@ -52,7 +72,7 @@ struct EmergencyContactsView: View {
                 }
                 .swipeActions(edge: .trailing) {
                     Button("Delete", role: .destructive) {
-                        Task { await viewModel.deleteContact(contact) }
+                        viewModel.confirmDeleteContact(contact)
                     }
                 }
             }

--- a/AarogyaiOS/Presentation/Emergency/EmergencyContactsViewModel.swift
+++ b/AarogyaiOS/Presentation/Emergency/EmergencyContactsViewModel.swift
@@ -7,8 +7,11 @@ final class EmergencyContactsViewModel {
     var contacts: [EmergencyContact] = []
     var isLoading = false
     var error: String?
+    var showError = false
     var editingContact: EmergencyContact?
     var showContactForm = false
+    var showDeleteConfirmation = false
+    var contactToDelete: EmergencyContact?
 
     let fetchUseCase: FetchEmergencyContactsUseCase
     let manageUseCase: ManageEmergencyContactUseCase
@@ -39,12 +42,21 @@ final class EmergencyContactsViewModel {
         isLoading = false
     }
 
-    func deleteContact(_ contact: EmergencyContact) async {
+    func confirmDeleteContact(_ contact: EmergencyContact) {
+        contactToDelete = contact
+        showDeleteConfirmation = true
+    }
+
+    func deleteContact() async {
+        guard let contact = contactToDelete else { return }
+        contactToDelete = nil
+
         do {
             try await manageUseCase.delete(id: contact.id)
             contacts.removeAll { $0.id == contact.id }
         } catch {
             self.error = "Failed to delete contact"
+            self.showError = true
             Logger.data.error("Delete contact failed: \(error)")
         }
     }

--- a/AarogyaiOSTests/Presentation/EmergencyContactsViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/EmergencyContactsViewModelTests.swift
@@ -28,14 +28,35 @@ struct EmergencyContactsViewModelTests {
         #expect(sut.error == "Failed to load contacts")
     }
 
+    @Test func confirmDeleteContactShowsConfirmation() async {
+        let sut = makeSUT()
+        await sut.loadContacts()
+        let contact = sut.contacts[0]
+
+        sut.confirmDeleteContact(contact)
+        #expect(sut.showDeleteConfirmation)
+        #expect(sut.contactToDelete?.id == contact.id)
+    }
+
     @Test func deleteContactRemovesFromList() async {
         let sut = makeSUT()
         await sut.loadContacts()
         let contact = sut.contacts[0]
 
-        await sut.deleteContact(contact)
+        sut.confirmDeleteContact(contact)
+        await sut.deleteContact()
         #expect(sut.contacts.isEmpty)
         #expect(contactRepo.deleteContactCallCount == 1)
+        #expect(sut.contactToDelete == nil)
+    }
+
+    @Test func deleteContactWithoutConfirmationDoesNothing() async {
+        let sut = makeSUT()
+        await sut.loadContacts()
+
+        await sut.deleteContact()
+        #expect(sut.contacts.count == 1)
+        #expect(contactRepo.deleteContactCallCount == 0)
     }
 
     @Test func deleteContactFailureSetsError() async {
@@ -43,8 +64,10 @@ struct EmergencyContactsViewModelTests {
         await sut.loadContacts()
         contactRepo.deleteContactResult = .failure(APIError.serverError(status: 500))
 
-        await sut.deleteContact(sut.contacts[0])
+        sut.confirmDeleteContact(sut.contacts[0])
+        await sut.deleteContact()
         #expect(sut.error == "Failed to delete contact")
+        #expect(sut.showError)
         #expect(sut.contacts.count == 1)
     }
 


### PR DESCRIPTION
## Summary
- Swipe-to-delete on emergency contact rows now shows a confirmation dialog before deleting
- Error alert displayed on delete failure with user-friendly message
- ViewModel uses two-step flow: `confirmDeleteContact` sets state, `deleteContact` executes after user confirms
- Guard clause in `deleteContact()` prevents deletion if no contact was confirmed

## Test plan
- [x] `confirmDeleteContactShowsConfirmation` — verifies confirmation state is set
- [x] `deleteContactRemovesFromList` — verifies full confirm-then-delete flow
- [x] `deleteContactWithoutConfirmationDoesNothing` — verifies guard clause
- [x] `deleteContactFailureSetsError` — verifies error alert state on failure
- [x] All existing emergency contact tests continue to pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)