### PR TITLE
feat(emergency-contacts): add isPrimary toggle and primary badge

### DIFF
--- a/AarogyaiOSTests/Domain/EmergencyContactUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/EmergencyContactUseCaseTests.swift
@@ -31,11 +31,29 @@ struct ManageEmergencyContactUseCaseTests {
         #expect(repo.createContactCallCount == 1)
     }
 
+    @Test func createContactPassesIsPrimary() async throws {
+        let input = EmergencyContactInput(name: "John", phone: "+911234567890", relationship: .spouse, isPrimary: true)
+        _ = try await sut.create(request: input)
+        #expect(repo.lastCreatedInput?.isPrimary == true)
+    }
+
+    @Test func createContactPassesIsPrimaryFalse() async throws {
+        let input = EmergencyContactInput(name: "John", phone: "+911234567890", relationship: .spouse, isPrimary: false)
+        _ = try await sut.create(request: input)
+        #expect(repo.lastCreatedInput?.isPrimary == false)
+    }
+
     @Test func updateContactCallsRepository() async throws {
         let input = EmergencyContactInput(name: "John Updated", phone: "+911234567890", relationship: .parent, isPrimary: false)
         let contact = try await sut.update(id: "contact-1", request: input)
         #expect(contact.id == "contact-1")
         #expect(repo.updateContactCallCount == 1)
+    }
+
+    @Test func updateContactPreservesIsPrimary() async throws {
+        let input = EmergencyContactInput(name: "John Updated", phone: "+911234567890", relationship: .parent, isPrimary: true)
+        _ = try await sut.update(id: "contact-1", request: input)
+        #expect(repo.lastUpdatedInput?.isPrimary == true)
     }
 
     @Test func deleteContactCallsRepository() async throws {

--- a/AarogyaiOSTests/Mocks/MockEmergencyContactRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockEmergencyContactRepository.swift
@@ -14,6 +14,9 @@ final class MockEmergencyContactRepository: EmergencyContactRepository, @uncheck
     var deleteContactCallCount = 0
 
     var lastDeletedContactId: String?
+    var lastCreatedInput: EmergencyContactInput?
+    var lastUpdatedInput: EmergencyContactInput?
+    var lastUpdatedId: String?
 
     func getContacts() async throws -> [EmergencyContact] {
         getContactsCallCount += 1
@@ -22,11 +25,14 @@ final class MockEmergencyContactRepository: EmergencyContactRepository, @uncheck
 
     func createContact(request: EmergencyContactInput) async throws -> EmergencyContact {
         createContactCallCount += 1
+        lastCreatedInput = request
         return try createContactResult.get()
     }
 
     func updateContact(id: String, request: EmergencyContactInput) async throws -> EmergencyContact {
         updateContactCallCount += 1
+        lastUpdatedId = id
+        lastUpdatedInput = request
         return try updateContactResult.get()
     }
 

--- a/AarogyaiOSTests/Presentation/EmergencyContactsViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/EmergencyContactsViewModelTests.swift
@@ -75,4 +75,42 @@ struct EmergencyContactsViewModelTests {
         #expect(sut.showContactForm)
         #expect(sut.editingContact?.id == contact.id)
     }
+
+    @Test func loadContactsPreservesIsPrimary() async {
+        let primary = EmergencyContact(
+            id: "c-1", name: "Primary", phone: "+91111",
+            relationship: .spouse, isPrimary: true, createdAt: .now, updatedAt: .now
+        )
+        let nonPrimary = EmergencyContact(
+            id: "c-2", name: "Secondary", phone: "+91222",
+            relationship: .parent, isPrimary: false, createdAt: .now, updatedAt: .now
+        )
+        contactRepo.getContactsResult = .success([primary, nonPrimary])
+        let sut = makeSUT()
+        await sut.loadContacts()
+
+        #expect(sut.contacts.count == 2)
+        #expect(sut.contacts[0].isPrimary == true)
+        #expect(sut.contacts[1].isPrimary == false)
+    }
+
+    @Test func editContactPreservesIsPrimaryState() {
+        let sut = makeSUT()
+        let contact = EmergencyContact(
+            id: "c-1", name: "Jane", phone: "+91111",
+            relationship: .spouse, isPrimary: true, createdAt: .now, updatedAt: .now
+        )
+        sut.editContact(contact)
+        #expect(sut.editingContact?.isPrimary == true)
+    }
+
+    @Test func editNonPrimaryContactPreservesIsPrimaryFalse() {
+        let sut = makeSUT()
+        let contact = EmergencyContact(
+            id: "c-2", name: "John", phone: "+91222",
+            relationship: .parent, isPrimary: false, createdAt: .now, updatedAt: .now
+        )
+        sut.editContact(contact)
+        #expect(sut.editingContact?.isPrimary == false)
+    }
 }


### PR DESCRIPTION
## Summary
- The `isPrimary` toggle in the emergency contact form and the "Primary" badge in the contact list were already implemented in the UI, ViewModel, domain, and data layers
- Added unit tests to verify `isPrimary` is correctly passed through create/update use cases and preserved in ViewModel state during load and edit operations
- Enhanced `MockEmergencyContactRepository` to capture `lastCreatedInput` and `lastUpdatedInput` for assertion in tests

## Test plan
- [x] `createContactPassesIsPrimary` — verifies `isPrimary: true` reaches the repository
- [x] `createContactPassesIsPrimaryFalse` — verifies `isPrimary: false` reaches the repository
- [x] `updateContactPreservesIsPrimary` — verifies update passes `isPrimary` through
- [x] `loadContactsPreservesIsPrimary` — verifies loaded contacts retain their `isPrimary` state
- [x] `editContactPreservesIsPrimaryState` — verifies editing a primary contact preserves `isPrimary: true`
- [x] `editNonPrimaryContactPreservesIsPrimaryFalse` — verifies editing a non-primary contact preserves `isPrimary: false`
- [x] All 154 tests pass

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)