### PR TITLE
feat(reports): implement extraction status view and trigger action

### DIFF
--- a/AarogyaiOS/App/DependencyContainer.swift
+++ b/AarogyaiOS/App/DependencyContainer.swift
@@ -48,6 +48,7 @@ final class DependencyContainer {
     let uploadReportUseCase: UploadReportUseCase
     let deleteReportUseCase: DeleteReportUseCase
     let downloadReportUseCase: DownloadReportUseCase
+    let extractionUseCase: ExtractionUseCase
 
     // MARK: - Use Cases — Access Grants
 
@@ -111,6 +112,7 @@ final class DependencyContainer {
             uploadReportUseCase = deps.uploadReport
             deleteReportUseCase = deps.deleteReport
             downloadReportUseCase = deps.downloadReport
+            extractionUseCase = deps.extraction
             fetchAccessGrantsUseCase = deps.fetchGrants
             createAccessGrantUseCase = deps.createGrant
             revokeAccessGrantUseCase = deps.revokeGrant
@@ -150,6 +152,7 @@ final class DependencyContainer {
             uploadReportUseCase = deps.uploadReport
             deleteReportUseCase = deps.deleteReport
             downloadReportUseCase = deps.downloadReport
+            extractionUseCase = deps.extraction
             fetchAccessGrantsUseCase = deps.fetchGrants
             createAccessGrantUseCase = deps.createGrant
             revokeAccessGrantUseCase = deps.revokeGrant
@@ -191,6 +194,7 @@ private struct DependencyBundle {
     let uploadReport: UploadReportUseCase
     let deleteReport: DeleteReportUseCase
     let downloadReport: DownloadReportUseCase
+    let extraction: ExtractionUseCase
     let fetchGrants: FetchAccessGrantsUseCase
     let createGrant: CreateAccessGrantUseCase
     let revokeGrant: RevokeAccessGrantUseCase
@@ -250,6 +254,7 @@ extension DependencyContainer {
             ),
             deleteReport: DeleteReportUseCase(reportRepository: reportRepo),
             downloadReport: DownloadReportUseCase(reportRepository: reportRepo),
+            extraction: ExtractionUseCase(reportRepository: reportRepo),
             fetchGrants: FetchAccessGrantsUseCase(accessGrantRepository: grantRepo),
             createGrant: CreateAccessGrantUseCase(accessGrantRepository: grantRepo),
             revokeGrant: RevokeAccessGrantUseCase(accessGrantRepository: grantRepo),
@@ -335,6 +340,7 @@ extension DependencyContainer {
             downloadReport: DownloadReportUseCase(
                 reportRepository: reportRepo
             ),
+            extraction: ExtractionUseCase(reportRepository: reportRepo),
             fetchGrants: FetchAccessGrantsUseCase(
                 accessGrantRepository: grantRepo
             ),

--- a/AarogyaiOS/Domain/UseCases/Reports/ExtractionUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/ExtractionUseCase.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct ExtractionUseCase: Sendable {
+    private let reportRepository: any ReportRepository
+
+    init(reportRepository: any ReportRepository) {
+        self.reportRepository = reportRepository
+    }
+
+    func getStatus(reportId: String) async throws -> ReportExtraction {
+        try await reportRepository.getExtractionStatus(reportId: reportId)
+    }
+
+    func trigger(reportId: String) async throws {
+        try await reportRepository.triggerExtraction(reportId: reportId)
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -19,6 +19,17 @@ struct TabCoordinator: View {
                     ReportsListView(viewModel: ReportsListViewModel(
                         fetchReportsUseCase: container.fetchReportsUseCase
                     ))
+                    .navigationDestination(for: Route.self) { route in
+                        if case .reportDetail(let id) = route {
+                            ReportDetailView(viewModel: ReportDetailViewModel(
+                                reportId: id,
+                                fetchReportsUseCase: container.fetchReportsUseCase,
+                                downloadReportUseCase: container.downloadReportUseCase,
+                                deleteReportUseCase: container.deleteReportUseCase,
+                                extractionUseCase: container.extractionUseCase
+                            ))
+                        }
+                    }
                 }
             }
 

--- a/AarogyaiOS/Presentation/Reports/ExtractionStatusView.swift
+++ b/AarogyaiOS/Presentation/Reports/ExtractionStatusView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+struct ExtractionStatusView: View {
+    @State var viewModel: ExtractionStatusViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            headerRow
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+            } else if let extraction = viewModel.extraction {
+                extractionDetails(extraction)
+            } else if let error = viewModel.error {
+                Text(error)
+                    .font(Typography.caption)
+                    .foregroundStyle(Color.Fallback.statusCritical)
+            }
+
+            if viewModel.canTriggerExtraction {
+                triggerButton
+            }
+        }
+        .padding(16)
+        .background(Color.Fallback.bgSecondary, in: RoundedRectangle(cornerRadius: 16))
+        .task { await viewModel.loadStatus() }
+    }
+
+    private var headerRow: some View {
+        HStack {
+            Text("Extraction")
+                .font(Typography.headline)
+            Spacer()
+            if let extraction = viewModel.extraction {
+                StatusBadge(extractionStatus: extraction.status)
+            }
+        }
+    }
+
+    private func extractionDetails(_ extraction: ReportExtraction) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if extraction.extractedParameterCount > 0 {
+                detailRow(
+                    "Parameters",
+                    value: "\(extraction.extractedParameterCount)"
+                )
+            }
+
+            if let confidence = viewModel.confidenceText {
+                detailRow("Confidence", value: confidence)
+            }
+
+            if let method = extraction.extractionMethod {
+                detailRow("Method", value: method.uppercased())
+            }
+
+            if let model = extraction.structuringModel {
+                detailRow("Model", value: model)
+            }
+
+            if let pageCount = extraction.pageCount {
+                detailRow("Pages", value: "\(pageCount)")
+            }
+
+            if let extractedAt = extraction.extractedAt {
+                detailRow(
+                    "Extracted",
+                    value: extractedAt.formatted(date: .abbreviated, time: .shortened)
+                )
+            }
+
+            if extraction.status == .failed, let errorMessage = extraction.errorMessage {
+                Text(errorMessage)
+                    .font(Typography.caption)
+                    .foregroundStyle(Color.Fallback.statusCritical)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private func detailRow(_ label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(Typography.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(Typography.data)
+        }
+    }
+
+    private var triggerButton: some View {
+        Button {
+            Task { await viewModel.triggerExtraction() }
+        } label: {
+            HStack(spacing: 8) {
+                if viewModel.isTriggering {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "wand.and.stars")
+                }
+                Text(viewModel.triggerButtonTitle)
+                    .font(Typography.headline)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+        }
+        .buttonStyle(.glass)
+        .disabled(viewModel.isTriggering)
+        .padding(.top, 4)
+    }
+}
+
+#if DEBUG
+#Preview("Completed") {
+    ExtractionStatusView(
+        viewModel: ExtractionStatusViewModel(
+            reportId: "rpt-1",
+            extractionUseCase: ExtractionUseCase(
+                reportRepository: PreviewExtractionRepo(status: .completed)
+            )
+        )
+    )
+    .padding()
+    .sereneBloomBackground()
+}
+
+#Preview("Failed") {
+    ExtractionStatusView(
+        viewModel: ExtractionStatusViewModel(
+            reportId: "rpt-1",
+            extractionUseCase: ExtractionUseCase(
+                reportRepository: PreviewExtractionRepo(status: .failed)
+            )
+        )
+    )
+    .padding()
+    .sereneBloomBackground()
+}
+
+#Preview("Pending") {
+    ExtractionStatusView(
+        viewModel: ExtractionStatusViewModel(
+            reportId: "rpt-1",
+            extractionUseCase: ExtractionUseCase(
+                reportRepository: PreviewExtractionRepo(status: .pending)
+            )
+        )
+    )
+    .padding()
+    .sereneBloomBackground()
+}
+
+private final class PreviewExtractionRepo: ReportRepository, @unchecked Sendable {
+    let status: ExtractionStatus
+
+    init(status: ExtractionStatus) {
+        self.status = status
+    }
+
+    // swiftlint:disable force_unwrapping line_length
+    func getReports(page: Int, pageSize: Int, type: ReportType?, status: ReportStatus?, search: String?) async throws -> PaginatedResult<Report> {
+        PaginatedResult(items: [], page: 1, pageSize: 20, totalCount: 0)
+    }
+    func getReport(id: String) async throws -> Report { PreviewData.report }
+    func createReport(request: CreateReportInput) async throws -> Report { PreviewData.report }
+    func deleteReport(id: String) async throws {}
+    func getUploadURL(fileName: String, contentType: String) async throws -> PresignedUpload {
+        PresignedUpload(uploadURL: URL(string: "https://example.com")!, fileStorageKey: "key")
+    }
+    func getDownloadURL(reportId: String) async throws -> URL { URL(string: "https://example.com")! }
+    func getVerifiedDownloadURL(reportId: String) async throws -> VerifiedDownload {
+        VerifiedDownload(downloadURL: URL(string: "https://example.com")!, checksumSha256: nil, isServerVerified: true)
+    }
+    // swiftlint:enable force_unwrapping line_length
+    func getExtractionStatus(reportId: String) async throws -> ReportExtraction {
+        ReportExtraction(
+            status: status,
+            extractionMethod: status == .completed ? "ai" : nil,
+            structuringModel: status == .completed ? "gpt-4" : nil,
+            extractedParameterCount: status == .completed ? 12 : 0,
+            overallConfidence: status == .completed ? 0.95 : nil,
+            pageCount: status == .completed ? 2 : nil,
+            extractedAt: status == .completed ? .now : nil,
+            errorMessage: status == .failed ? "OCR processing failed" : nil,
+            attemptCount: status == .failed ? 2 : (status == .completed ? 1 : 0)
+        )
+    }
+    func triggerExtraction(reportId: String) async throws {}
+}
+#endif

--- a/AarogyaiOS/Presentation/Reports/ExtractionStatusViewModel.swift
+++ b/AarogyaiOS/Presentation/Reports/ExtractionStatusViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class ExtractionStatusViewModel {
+    var extraction: ReportExtraction?
+    var isLoading = false
+    var isTriggering = false
+    var error: String?
+
+    private let reportId: String
+    private let extractionUseCase: ExtractionUseCase
+
+    init(reportId: String, extractionUseCase: ExtractionUseCase) {
+        self.reportId = reportId
+        self.extractionUseCase = extractionUseCase
+    }
+
+    var canTriggerExtraction: Bool {
+        guard !isTriggering else { return false }
+        guard let extraction else { return true }
+        return extraction.status == .pending || extraction.status == .failed
+    }
+
+    var triggerButtonTitle: String {
+        guard let extraction else { return "Extract" }
+        return extraction.attemptCount > 0 && extraction.status == .failed
+            ? "Re-extract"
+            : "Extract"
+    }
+
+    var confidenceText: String? {
+        guard let confidence = extraction?.overallConfidence else { return nil }
+        return "\(Int(confidence * 100))%"
+    }
+
+    func loadStatus() async {
+        isLoading = true
+        error = nil
+
+        do {
+            extraction = try await extractionUseCase.getStatus(reportId: reportId)
+        } catch {
+            self.error = "Failed to load extraction status"
+            Logger.data.error("Load extraction status failed: \(error)")
+        }
+
+        isLoading = false
+    }
+
+    func triggerExtraction() async {
+        guard canTriggerExtraction else { return }
+
+        isTriggering = true
+        error = nil
+
+        do {
+            try await extractionUseCase.trigger(reportId: reportId)
+            // Reload status after triggering
+            extraction = try await extractionUseCase.getStatus(reportId: reportId)
+        } catch {
+            self.error = "Failed to trigger extraction"
+            Logger.data.error("Trigger extraction failed: \(error)")
+        }
+
+        isTriggering = false
+    }
+}

--- a/AarogyaiOS/Presentation/Reports/ReportDetailView.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportDetailView.swift
@@ -57,6 +57,9 @@ struct ReportDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 reportHeader(report)
+                if let extractionVM = viewModel.extractionViewModel {
+                    ExtractionStatusView(viewModel: extractionVM)
+                }
                 if !report.parameters.isEmpty {
                     parametersSection(report.parameters)
                 }

--- a/AarogyaiOS/Presentation/Reports/ReportDetailViewModel.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportDetailViewModel.swift
@@ -10,22 +10,26 @@ final class ReportDetailViewModel {
     var downloadURL: URL?
     var showDeleteConfirmation = false
     var isDeleting = false
+    var extractionViewModel: ExtractionStatusViewModel?
 
     private let reportId: String
     private let fetchReportsUseCase: FetchReportsUseCase
     private let downloadReportUseCase: DownloadReportUseCase
     private let deleteReportUseCase: DeleteReportUseCase
+    private let extractionUseCase: ExtractionUseCase
 
     init(
         reportId: String,
         fetchReportsUseCase: FetchReportsUseCase,
         downloadReportUseCase: DownloadReportUseCase,
-        deleteReportUseCase: DeleteReportUseCase
+        deleteReportUseCase: DeleteReportUseCase,
+        extractionUseCase: ExtractionUseCase
     ) {
         self.reportId = reportId
         self.fetchReportsUseCase = fetchReportsUseCase
         self.downloadReportUseCase = downloadReportUseCase
         self.deleteReportUseCase = deleteReportUseCase
+        self.extractionUseCase = extractionUseCase
     }
 
     func loadReport() async {
@@ -35,6 +39,12 @@ final class ReportDetailViewModel {
         do {
             let result = try await fetchReportsUseCase.execute(search: reportId)
             report = result.items.first
+            if report != nil {
+                extractionViewModel = ExtractionStatusViewModel(
+                    reportId: reportId,
+                    extractionUseCase: extractionUseCase
+                )
+            }
         } catch {
             self.error = "Failed to load report details"
             Logger.data.error("Load report detail failed: \(error)")

--- a/AarogyaiOS/Presentation/SharedComponents/Glass/StatusBadge.swift
+++ b/AarogyaiOS/Presentation/SharedComponents/Glass/StatusBadge.swift
@@ -28,6 +28,25 @@ extension StatusBadge {
         }
     }
 
+    init(extractionStatus: ExtractionStatus) {
+        self.text = switch extractionStatus {
+        case .pending: "Pending"
+        case .inProgress: "Processing"
+        case .completed: "Completed"
+        case .failed: "Failed"
+        }
+        self.color = switch extractionStatus {
+        case .completed:
+            Color.Fallback.statusNormal
+        case .failed:
+            Color.Fallback.statusCritical
+        case .inProgress:
+            Color.Fallback.statusWarning
+        case .pending:
+            Color.Fallback.statusInfo
+        }
+    }
+
     init(accessGrantStatus: AccessGrantStatus) {
         self.text = accessGrantStatus.rawValue.capitalized
         self.color = switch accessGrantStatus {

--- a/AarogyaiOS/Utilities/AccessibilityID.swift
+++ b/AarogyaiOS/Utilities/AccessibilityID.swift
@@ -39,6 +39,15 @@ enum AccessibilityID {
         static let labName = "reportDetail.lab"
     }
 
+    // MARK: - Extraction
+    enum Extraction {
+        static let section = "extraction.section"
+        static let statusBadge = "extraction.statusBadge"
+        static let triggerButton = "extraction.trigger.button"
+        static let parameterCount = "extraction.parameterCount"
+        static let confidence = "extraction.confidence"
+    }
+
     // MARK: - Access Grants
     enum AccessGrants {
         static let emptyState = "accessGrants.emptyState"

--- a/AarogyaiOSTests/Domain/ExtractionUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/ExtractionUseCaseTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("ExtractionUseCase")
+@MainActor
+struct ExtractionUseCaseTests {
+    let reportRepo = MockReportRepository()
+
+    func makeSUT() -> ExtractionUseCase {
+        ExtractionUseCase(reportRepository: reportRepo)
+    }
+
+    // MARK: - getStatus
+
+    @Test func getStatusReturnsExtraction() async throws {
+        reportRepo.getExtractionStatusResult = .success(.stubCompleted)
+        let sut = makeSUT()
+
+        let result = try await sut.getStatus(reportId: "report-1")
+
+        #expect(result.status == .completed)
+        #expect(result.extractedParameterCount == 12)
+        #expect(result.overallConfidence == 0.95)
+        #expect(result.extractionMethod == "ai")
+        #expect(result.structuringModel == "gpt-4")
+        #expect(result.attemptCount == 1)
+        #expect(reportRepo.getExtractionStatusCallCount == 1)
+        #expect(reportRepo.lastExtractionReportId == "report-1")
+    }
+
+    @Test func getStatusPropagatesError() async {
+        reportRepo.getExtractionStatusResult = .failure(APIError.notFound)
+        let sut = makeSUT()
+
+        do {
+            _ = try await sut.getStatus(reportId: "invalid")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(error is APIError)
+        }
+    }
+
+    @Test func getStatusPassesCorrectReportId() async throws {
+        let sut = makeSUT()
+        _ = try await sut.getStatus(reportId: "my-report-id")
+        #expect(reportRepo.lastExtractionReportId == "my-report-id")
+    }
+
+    // MARK: - trigger
+
+    @Test func triggerCallsRepository() async throws {
+        let sut = makeSUT()
+
+        try await sut.trigger(reportId: "report-1")
+
+        #expect(reportRepo.triggerExtractionCallCount == 1)
+        #expect(reportRepo.lastExtractionReportId == "report-1")
+    }
+
+    @Test func triggerPropagatesError() async {
+        reportRepo.triggerExtractionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        do {
+            try await sut.trigger(reportId: "report-1")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(error is APIError)
+        }
+    }
+
+    @Test func triggerPassesCorrectReportId() async throws {
+        let sut = makeSUT()
+        try await sut.trigger(reportId: "another-report")
+        #expect(reportRepo.lastExtractionReportId == "another-report")
+    }
+}

--- a/AarogyaiOSTests/Mocks/MockReportRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockReportRepository.swift
@@ -39,10 +39,13 @@ final class MockReportRepository: ReportRepository, @unchecked Sendable {
     var getUploadURLCallCount = 0
     var getDownloadURLCallCount = 0
     var getVerifiedDownloadURLCallCount = 0
+    var getExtractionStatusCallCount = 0
+    var triggerExtractionCallCount = 0
     var invalidateCacheCallCount = 0
 
     var lastGetReportsPage: Int?
     var lastDeletedReportId: String?
+    var lastExtractionReportId: String?
 
     func getReports(
         page: Int, pageSize: Int, type: ReportType?,
@@ -101,10 +104,14 @@ final class MockReportRepository: ReportRepository, @unchecked Sendable {
     }
 
     func getExtractionStatus(reportId: String) async throws -> ReportExtraction {
-        try getExtractionStatusResult.get()
+        getExtractionStatusCallCount += 1
+        lastExtractionReportId = reportId
+        return try getExtractionStatusResult.get()
     }
 
     func triggerExtraction(reportId: String) async throws {
+        triggerExtractionCallCount += 1
+        lastExtractionReportId = reportId
         try triggerExtractionResult.get()
     }
 

--- a/AarogyaiOSTests/Mocks/TestStubs.swift
+++ b/AarogyaiOSTests/Mocks/TestStubs.swift
@@ -136,6 +136,56 @@ extension EmergencyAccessAuditEntry {
     )
 }
 
+extension ReportExtraction {
+    static let stubCompleted = ReportExtraction(
+        status: .completed,
+        extractionMethod: "ai",
+        structuringModel: "gpt-4",
+        extractedParameterCount: 12,
+        overallConfidence: 0.95,
+        pageCount: 2,
+        extractedAt: Date(timeIntervalSince1970: 1_700_000_000),
+        errorMessage: nil,
+        attemptCount: 1
+    )
+
+    static let stubPending = ReportExtraction(
+        status: .pending,
+        extractionMethod: nil,
+        structuringModel: nil,
+        extractedParameterCount: 0,
+        overallConfidence: nil,
+        pageCount: nil,
+        extractedAt: nil,
+        errorMessage: nil,
+        attemptCount: 0
+    )
+
+    static let stubFailed = ReportExtraction(
+        status: .failed,
+        extractionMethod: "ai",
+        structuringModel: nil,
+        extractedParameterCount: 0,
+        overallConfidence: nil,
+        pageCount: nil,
+        extractedAt: nil,
+        errorMessage: "OCR processing failed for this document",
+        attemptCount: 2
+    )
+
+    static let stubInProgress = ReportExtraction(
+        status: .inProgress,
+        extractionMethod: "ai",
+        structuringModel: nil,
+        extractedParameterCount: 0,
+        overallConfidence: nil,
+        pageCount: nil,
+        extractedAt: nil,
+        errorMessage: nil,
+        attemptCount: 1
+    )
+}
+
 extension NotificationPreferences {
     static let stub = NotificationPreferences(
         reportUploaded: ChannelPreferences(push: true, email: true, sms: false),

--- a/AarogyaiOSTests/Presentation/ExtractionStatusViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/ExtractionStatusViewModelTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("ExtractionStatusViewModel")
+@MainActor
+struct ExtractionStatusViewModelTests {
+    let reportRepo = MockReportRepository()
+
+    func makeSUT(reportId: String = "report-1") -> ExtractionStatusViewModel {
+        let useCase = ExtractionUseCase(reportRepository: reportRepo)
+        return ExtractionStatusViewModel(reportId: reportId, extractionUseCase: useCase)
+    }
+
+    // MARK: - Load Status
+
+    @Test func loadStatusSuccess() async {
+        reportRepo.getExtractionStatusResult = .success(.stubCompleted)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        #expect(sut.extraction != nil)
+        #expect(sut.extraction?.status == .completed)
+        #expect(sut.error == nil)
+        #expect(!sut.isLoading)
+        #expect(reportRepo.getExtractionStatusCallCount == 1)
+        #expect(reportRepo.lastExtractionReportId == "report-1")
+    }
+
+    @Test func loadStatusFailure() async {
+        reportRepo.getExtractionStatusResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        #expect(sut.extraction == nil)
+        #expect(sut.error == "Failed to load extraction status")
+        #expect(!sut.isLoading)
+    }
+
+    @Test func loadStatusPending() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        #expect(sut.extraction?.status == .pending)
+        #expect(sut.extraction?.extractedParameterCount == 0)
+    }
+
+    @Test func loadStatusInProgress() async {
+        reportRepo.getExtractionStatusResult = .success(.stubInProgress)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        #expect(sut.extraction?.status == .inProgress)
+    }
+
+    @Test func loadStatusFailed() async {
+        reportRepo.getExtractionStatusResult = .success(.stubFailed)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        #expect(sut.extraction?.status == .failed)
+        #expect(sut.extraction?.errorMessage == "OCR processing failed for this document")
+        #expect(sut.extraction?.attemptCount == 2)
+    }
+
+    // MARK: - Trigger Extraction
+
+    @Test func triggerExtractionSuccess() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+        #expect(sut.canTriggerExtraction)
+
+        reportRepo.getExtractionStatusResult = .success(.stubInProgress)
+        await sut.triggerExtraction()
+
+        #expect(sut.extraction?.status == .inProgress)
+        #expect(sut.error == nil)
+        #expect(!sut.isTriggering)
+        #expect(reportRepo.triggerExtractionCallCount == 1)
+        // loadStatus(1) + triggerExtraction reloads status(1) = 2 total
+        #expect(reportRepo.getExtractionStatusCallCount == 2)
+    }
+
+    @Test func triggerExtractionFailure() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+
+        reportRepo.triggerExtractionResult = .failure(APIError.serverError(status: 500))
+        await sut.triggerExtraction()
+
+        #expect(sut.error == "Failed to trigger extraction")
+        #expect(!sut.isTriggering)
+    }
+
+    @Test func triggerExtractionFromFailedState() async {
+        reportRepo.getExtractionStatusResult = .success(.stubFailed)
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+        #expect(sut.canTriggerExtraction)
+        #expect(sut.triggerButtonTitle == "Re-extract")
+
+        reportRepo.getExtractionStatusResult = .success(.stubInProgress)
+        await sut.triggerExtraction()
+
+        #expect(sut.extraction?.status == .inProgress)
+        #expect(reportRepo.triggerExtractionCallCount == 1)
+    }
+
+    // MARK: - canTriggerExtraction
+
+    @Test func canTriggerExtractionWhenNoExtraction() {
+        let sut = makeSUT()
+        #expect(sut.canTriggerExtraction)
+    }
+
+    @Test func canTriggerExtractionWhenPending() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.canTriggerExtraction)
+    }
+
+    @Test func canTriggerExtractionWhenFailed() async {
+        reportRepo.getExtractionStatusResult = .success(.stubFailed)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.canTriggerExtraction)
+    }
+
+    @Test func cannotTriggerExtractionWhenCompleted() async {
+        reportRepo.getExtractionStatusResult = .success(.stubCompleted)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(!sut.canTriggerExtraction)
+    }
+
+    @Test func cannotTriggerExtractionWhenInProgress() async {
+        reportRepo.getExtractionStatusResult = .success(.stubInProgress)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(!sut.canTriggerExtraction)
+    }
+
+    // MARK: - triggerButtonTitle
+
+    @Test func triggerButtonTitleExtractWhenNoExtraction() {
+        let sut = makeSUT()
+        #expect(sut.triggerButtonTitle == "Extract")
+    }
+
+    @Test func triggerButtonTitleExtractWhenPending() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.triggerButtonTitle == "Extract")
+    }
+
+    @Test func triggerButtonTitleReExtractWhenFailed() async {
+        reportRepo.getExtractionStatusResult = .success(.stubFailed)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.triggerButtonTitle == "Re-extract")
+    }
+
+    // MARK: - confidenceText
+
+    @Test func confidenceTextWhenCompleted() async {
+        reportRepo.getExtractionStatusResult = .success(.stubCompleted)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.confidenceText == "95%")
+    }
+
+    @Test func confidenceTextNilWhenPending() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+        await sut.loadStatus()
+        #expect(sut.confidenceText == nil)
+    }
+
+    @Test func confidenceTextNilWhenNoExtraction() {
+        let sut = makeSUT()
+        #expect(sut.confidenceText == nil)
+    }
+
+    // MARK: - Report ID Passed Correctly
+
+    @Test func reportIdPassedToRepository() async {
+        let sut = makeSUT(reportId: "custom-report-id")
+        await sut.loadStatus()
+        #expect(reportRepo.lastExtractionReportId == "custom-report-id")
+    }
+
+    @Test func triggerPassesReportIdToRepository() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT(reportId: "trigger-report-id")
+        await sut.loadStatus()
+        await sut.triggerExtraction()
+        #expect(reportRepo.lastExtractionReportId == "trigger-report-id")
+    }
+
+    // MARK: - Error Cleared on Retry
+
+    @Test func errorClearedOnRetryLoadStatus() async {
+        reportRepo.getExtractionStatusResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        await sut.loadStatus()
+        #expect(sut.error != nil)
+
+        reportRepo.getExtractionStatusResult = .success(.stubCompleted)
+        await sut.loadStatus()
+        #expect(sut.error == nil)
+        #expect(sut.extraction?.status == .completed)
+    }
+
+    @Test func errorClearedOnRetryTrigger() async {
+        reportRepo.getExtractionStatusResult = .success(.stubPending)
+        let sut = makeSUT()
+        await sut.loadStatus()
+
+        reportRepo.triggerExtractionResult = .failure(APIError.serverError(status: 500))
+        await sut.triggerExtraction()
+        #expect(sut.error != nil)
+
+        reportRepo.triggerExtractionResult = .success(())
+        reportRepo.getExtractionStatusResult = .success(.stubInProgress)
+        await sut.triggerExtraction()
+        #expect(sut.error == nil)
+    }
+}

--- a/AarogyaiOSTests/Presentation/ReportDetailViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/ReportDetailViewModelTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("ReportDetailViewModel")
+@MainActor
+struct ReportDetailViewModelTests {
+    let reportRepo = MockReportRepository()
+
+    func makeSUT(reportId: String = "report-1") -> ReportDetailViewModel {
+        let fetchUseCase = FetchReportsUseCase(reportRepository: reportRepo)
+        let downloadUseCase = DownloadReportUseCase(reportRepository: reportRepo)
+        let deleteUseCase = DeleteReportUseCase(reportRepository: reportRepo)
+        let extractionUseCase = ExtractionUseCase(reportRepository: reportRepo)
+        return ReportDetailViewModel(
+            reportId: reportId,
+            fetchReportsUseCase: fetchUseCase,
+            downloadReportUseCase: downloadUseCase,
+            deleteReportUseCase: deleteUseCase,
+            extractionUseCase: extractionUseCase
+        )
+    }
+
+    // MARK: - Load Report
+
+    @Test func loadReportSuccess() async {
+        let sut = makeSUT()
+
+        await sut.loadReport()
+
+        #expect(sut.report != nil)
+        #expect(sut.error == nil)
+        #expect(!sut.isLoading)
+    }
+
+    @Test func loadReportCreatesExtractionViewModel() async {
+        let sut = makeSUT()
+
+        await sut.loadReport()
+
+        #expect(sut.extractionViewModel != nil)
+    }
+
+    @Test func loadReportFailure() async {
+        reportRepo.getReportsResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        await sut.loadReport()
+
+        #expect(sut.report == nil)
+        #expect(sut.error == "Failed to load report details")
+        #expect(sut.extractionViewModel == nil)
+    }
+
+    @Test func loadReportNoExtractionViewModelWhenNoReport() async {
+        reportRepo.getReportsResult = .success(
+            PaginatedResult(items: [], page: 1, pageSize: 20, totalCount: 0)
+        )
+        let sut = makeSUT()
+
+        await sut.loadReport()
+
+        #expect(sut.report == nil)
+        #expect(sut.extractionViewModel == nil)
+    }
+
+    // MARK: - Download
+
+    @Test func downloadSuccess() async {
+        let sut = makeSUT()
+
+        await sut.download()
+
+        #expect(sut.downloadURL != nil)
+        #expect(sut.error == nil)
+    }
+
+    @Test func downloadFailure() async {
+        reportRepo.getDownloadURLResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        await sut.download()
+
+        #expect(sut.downloadURL == nil)
+        #expect(sut.error == "Failed to generate download link")
+    }
+
+    // MARK: - Delete
+
+    @Test func deleteReportSuccess() async {
+        let sut = makeSUT()
+
+        let result = await sut.deleteReport()
+
+        #expect(result)
+        #expect(!sut.isDeleting)
+    }
+
+    @Test func deleteReportFailure() async {
+        reportRepo.deleteReportResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        let result = await sut.deleteReport()
+
+        #expect(!result)
+        #expect(sut.error == "Failed to delete report")
+        #expect(!sut.isDeleting)
+    }
+
+    // MARK: - Initial State
+
+    @Test func initialState() {
+        let sut = makeSUT()
+
+        #expect(sut.report == nil)
+        #expect(!sut.isLoading)
+        #expect(sut.error == nil)
+        #expect(sut.downloadURL == nil)
+        #expect(!sut.showDeleteConfirmation)
+        #expect(!sut.isDeleting)
+        #expect(sut.extractionViewModel == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ExtractionStatusView` section to report detail page showing extraction status badge, parameter count, confidence, method, model, page count, and extracted-at timestamp
- Include Extract/Re-extract glass button for pending/failed extraction states with loading indicator during trigger
- Wire `ExtractionUseCase` through `DependencyContainer` and create `ExtractionStatusViewModel` with `@Observable` pattern
- Add `StatusBadge(extractionStatus:)` initializer for all four extraction states (pending, in-progress, completed, failed)
- Connect `ReportDetailView` navigation from `TabCoordinator` with all required use cases

## Test plan
- [x] `ExtractionStatusViewModelTests` (22 tests): load status success/failure for all states, trigger extraction success/failure, canTriggerExtraction logic, button title, confidence text, report ID passing, error clearing on retry
- [x] `ExtractionUseCaseTests` (6 tests): getStatus/trigger with success, error propagation, correct report ID passing
- [x] `ReportDetailViewModelTests` (8 tests): load report creates extraction VM, failure/empty states, download, delete, initial state
- [x] All 259 unit tests pass

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)