### PR TITLE
feat(reports): implement delete report with confirmation

### DIFF
--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -12,13 +12,13 @@ struct TabCoordinator: View {
     @Binding var selectedTab: AppTab
     let onSignOut: () async -> Void
 
+    @State private var reportsListViewModel: ReportsListViewModel?
+
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Reports", systemImage: "doc.text", value: .reports) {
                 NavigationStack {
-                    ReportsListView(viewModel: ReportsListViewModel(
-                        fetchReportsUseCase: container.fetchReportsUseCase
-                    ))
+                    ReportsListView(viewModel: resolveReportsListViewModel())
                     .navigationDestination(for: Route.self) { route in
                         if case .reportDetail(let id) = route {
                             ReportDetailView(viewModel: ReportDetailViewModel(
@@ -26,7 +26,10 @@ struct TabCoordinator: View {
                                 fetchReportsUseCase: container.fetchReportsUseCase,
                                 downloadReportUseCase: container.downloadReportUseCase,
                                 deleteReportUseCase: container.deleteReportUseCase,
-                                extractionUseCase: container.extractionUseCase
+                                extractionUseCase: container.extractionUseCase,
+                                onDelete: { [reportsListViewModel] in
+                                    reportsListViewModel?.markNeedsRefresh()
+                                }
                             ))
                         }
                     }
@@ -80,5 +83,16 @@ struct TabCoordinator: View {
             }
         }
         .tabBarMinimizeBehavior(.onScrollDown)
+    }
+
+    private func resolveReportsListViewModel() -> ReportsListViewModel {
+        if let existing = reportsListViewModel {
+            return existing
+        }
+        let viewModel = ReportsListViewModel(
+            fetchReportsUseCase: container.fetchReportsUseCase
+        )
+        reportsListViewModel = viewModel
+        return viewModel
     }
 }

--- a/AarogyaiOS/Presentation/Reports/ReportDetailView.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportDetailView.swift
@@ -50,6 +50,18 @@ struct ReportDetailView: View {
         } message: {
             Text("This action cannot be undone.")
         }
+        .overlay {
+            if viewModel.isDeleting {
+                ZStack {
+                    Color.black.opacity(0.3)
+                        .ignoresSafeArea()
+                    ProgressView("Deleting...")
+                        .padding(24)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+                }
+            }
+        }
+        .allowsHitTesting(!viewModel.isDeleting)
         .task { await viewModel.loadReport() }
     }
 

--- a/AarogyaiOS/Presentation/Reports/ReportDetailViewModel.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportDetailViewModel.swift
@@ -17,19 +17,22 @@ final class ReportDetailViewModel {
     private let downloadReportUseCase: DownloadReportUseCase
     private let deleteReportUseCase: DeleteReportUseCase
     private let extractionUseCase: ExtractionUseCase
+    private let onDelete: (@Sendable () -> Void)?
 
     init(
         reportId: String,
         fetchReportsUseCase: FetchReportsUseCase,
         downloadReportUseCase: DownloadReportUseCase,
         deleteReportUseCase: DeleteReportUseCase,
-        extractionUseCase: ExtractionUseCase
+        extractionUseCase: ExtractionUseCase,
+        onDelete: (@Sendable () -> Void)? = nil
     ) {
         self.reportId = reportId
         self.fetchReportsUseCase = fetchReportsUseCase
         self.downloadReportUseCase = downloadReportUseCase
         self.deleteReportUseCase = deleteReportUseCase
         self.extractionUseCase = extractionUseCase
+        self.onDelete = onDelete
     }
 
     func loadReport() async {
@@ -68,6 +71,7 @@ final class ReportDetailViewModel {
 
         do {
             try await deleteReportUseCase.execute(reportId: reportId)
+            onDelete?()
             return true
         } catch {
             self.error = "Failed to delete report"

--- a/AarogyaiOS/Presentation/Reports/ReportsListView.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportsListView.swift
@@ -19,6 +19,7 @@ struct ReportsListView: View {
         .onSubmit(of: .search) { viewModel.search() }
         .refreshable { await viewModel.refresh() }
         .task { await viewModel.loadReports() }
+        .onAppear { Task { await viewModel.refreshIfNeeded() } }
         .sheet(isPresented: $showUpload) {
             Text("Upload Report") // Placeholder for ReportUploadView
         }

--- a/AarogyaiOS/Presentation/Reports/ReportsListViewModel.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportsListViewModel.swift
@@ -13,6 +13,7 @@ final class ReportsListViewModel {
     var hasMorePages = true
     var isFromCache = false
     var lastFetchedAt: Date?
+    var needsRefresh = false
 
     private var currentPage = 1
     private let pageSize = Constants.Pagination.defaultPageSize
@@ -87,6 +88,16 @@ final class ReportsListViewModel {
         }
 
         isLoadingMore = false
+    }
+
+    func markNeedsRefresh() {
+        needsRefresh = true
+    }
+
+    func refreshIfNeeded() async {
+        guard needsRefresh else { return }
+        needsRefresh = false
+        await loadReports()
     }
 
     func refresh() async {

--- a/AarogyaiOSTests/Domain/FetchReportsUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/FetchReportsUseCaseTests.swift
@@ -70,6 +70,18 @@ struct DeleteReportUseCaseTests {
         #expect(reportRepo.deleteReportCallCount == 1)
         #expect(reportRepo.lastDeletedReportId == "report-1")
     }
+
+    @Test func executePropagatesError() async {
+        reportRepo.deleteReportResult = .failure(APIError.serverError(status: 500))
+        await #expect(throws: APIError.self) {
+            try await sut.execute(reportId: "report-1")
+        }
+    }
+
+    @Test func executePassesCorrectReportId() async throws {
+        try await sut.execute(reportId: "custom-id-123")
+        #expect(reportRepo.lastDeletedReportId == "custom-id-123")
+    }
 }
 
 @Suite("UploadReportUseCase")

--- a/AarogyaiOSTests/Presentation/ReportDetailViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/ReportDetailViewModelTests.swift
@@ -2,12 +2,19 @@ import Foundation
 import Testing
 @testable import AarogyaiOS
 
+private final class CallTracker: @unchecked Sendable {
+    var called = false
+}
+
 @Suite("ReportDetailViewModel")
 @MainActor
 struct ReportDetailViewModelTests {
     let reportRepo = MockReportRepository()
 
-    func makeSUT(reportId: String = "report-1") -> ReportDetailViewModel {
+    func makeSUT(
+        reportId: String = "report-1",
+        onDelete: (@Sendable () -> Void)? = nil
+    ) -> ReportDetailViewModel {
         let fetchUseCase = FetchReportsUseCase(reportRepository: reportRepo)
         let downloadUseCase = DownloadReportUseCase(reportRepository: reportRepo)
         let deleteUseCase = DeleteReportUseCase(reportRepository: reportRepo)
@@ -17,7 +24,8 @@ struct ReportDetailViewModelTests {
             fetchReportsUseCase: fetchUseCase,
             downloadReportUseCase: downloadUseCase,
             deleteReportUseCase: deleteUseCase,
-            extractionUseCase: extractionUseCase
+            extractionUseCase: extractionUseCase,
+            onDelete: onDelete
         )
     }
 
@@ -94,6 +102,16 @@ struct ReportDetailViewModelTests {
 
         #expect(result)
         #expect(!sut.isDeleting)
+        #expect(sut.error == nil)
+    }
+
+    @Test func deleteReportCallsRepositoryWithCorrectId() async {
+        let sut = makeSUT(reportId: "report-42")
+
+        _ = await sut.deleteReport()
+
+        #expect(reportRepo.deleteReportCallCount == 1)
+        #expect(reportRepo.lastDeletedReportId == "report-42")
     }
 
     @Test func deleteReportFailure() async {
@@ -105,6 +123,79 @@ struct ReportDetailViewModelTests {
         #expect(!result)
         #expect(sut.error == "Failed to delete report")
         #expect(!sut.isDeleting)
+    }
+
+    @Test func deleteReportFailureDoesNotClearExistingReport() async {
+        let sut = makeSUT()
+        await sut.loadReport()
+        #expect(sut.report != nil)
+
+        reportRepo.deleteReportResult = .failure(APIError.serverError(status: 500))
+        _ = await sut.deleteReport()
+
+        #expect(sut.report != nil)
+    }
+
+    @Test func deleteReportSuccessCallsOnDelete() async {
+        let tracker = CallTracker()
+        let sut = makeSUT(onDelete: { tracker.called = true })
+
+        let result = await sut.deleteReport()
+
+        #expect(result)
+        #expect(tracker.called)
+    }
+
+    @Test func deleteReportFailureDoesNotCallOnDelete() async {
+        reportRepo.deleteReportResult = .failure(APIError.serverError(status: 500))
+        let tracker = CallTracker()
+        let sut = makeSUT(onDelete: { tracker.called = true })
+
+        let result = await sut.deleteReport()
+
+        #expect(!result)
+        #expect(!tracker.called)
+    }
+
+    @Test func deleteReportWithNoOnDeleteCallback() async {
+        let sut = makeSUT()
+
+        let result = await sut.deleteReport()
+
+        #expect(result)
+    }
+
+    @Test func deleteReportNetworkError() async {
+        reportRepo.deleteReportResult = .failure(APIError.networkError(underlying: URLError(.notConnectedToInternet)))
+        let sut = makeSUT()
+
+        let result = await sut.deleteReport()
+
+        #expect(!result)
+        #expect(sut.error == "Failed to delete report")
+    }
+
+    @Test func deleteReportUnauthorizedError() async {
+        reportRepo.deleteReportResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+
+        let result = await sut.deleteReport()
+
+        #expect(!result)
+        #expect(sut.error == "Failed to delete report")
+    }
+
+    // MARK: - Show Delete Confirmation
+
+    @Test func showDeleteConfirmationStartsFalse() {
+        let sut = makeSUT()
+        #expect(!sut.showDeleteConfirmation)
+    }
+
+    @Test func showDeleteConfirmationCanBeToggled() {
+        let sut = makeSUT()
+        sut.showDeleteConfirmation = true
+        #expect(sut.showDeleteConfirmation)
     }
 
     // MARK: - Initial State

--- a/AarogyaiOSTests/Presentation/ReportsListViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/ReportsListViewModelTests.swift
@@ -91,4 +91,48 @@ struct ReportsListViewModelTests {
         await sut.loadReports()
         #expect(sut.stalenessText == nil)
     }
+
+    // MARK: - Needs Refresh
+
+    @Test func needsRefreshStartsFalse() {
+        let sut = makeSUT()
+        #expect(!sut.needsRefresh)
+    }
+
+    @Test func markNeedsRefreshSetsFlag() {
+        let sut = makeSUT()
+        sut.markNeedsRefresh()
+        #expect(sut.needsRefresh)
+    }
+
+    @Test func refreshIfNeededReloadsWhenFlagSet() async {
+        let sut = makeSUT()
+        await sut.loadReports()
+        let callCountBefore = reportRepo.getReportsWithCacheCallCount
+
+        sut.markNeedsRefresh()
+        await sut.refreshIfNeeded()
+
+        #expect(reportRepo.getReportsWithCacheCallCount == callCountBefore + 1)
+        #expect(!sut.needsRefresh)
+    }
+
+    @Test func refreshIfNeededDoesNothingWhenFlagNotSet() async {
+        let sut = makeSUT()
+        await sut.loadReports()
+        let callCountBefore = reportRepo.getReportsWithCacheCallCount
+
+        await sut.refreshIfNeeded()
+
+        #expect(reportRepo.getReportsWithCacheCallCount == callCountBefore)
+    }
+
+    @Test func refreshIfNeededClearsFlagAfterRefresh() async {
+        let sut = makeSUT()
+        sut.markNeedsRefresh()
+
+        await sut.refreshIfNeeded()
+
+        #expect(!sut.needsRefresh)
+    }
 }


### PR DESCRIPTION
## Summary
- Wire delete action in `ReportDetailView` with confirmation dialog and loading overlay during deletion
- Add `onDelete` callback from `ReportDetailViewModel` to notify the reports list to refresh after successful deletion
- Add `needsRefresh` / `refreshIfNeeded()` mechanism to `ReportsListViewModel` so the list reloads when navigating back after a delete
- Add comprehensive unit tests for the delete flow (success, failure, error types, callback behavior, list refresh)

Closes #100

## Test plan
- [ ] Tap trash icon on report detail -> confirmation dialog appears
- [ ] Cancel confirmation -> report preserved, no deletion
- [ ] Confirm deletion -> loading overlay shown, report deleted, navigates back to list
- [ ] Reports list refreshes automatically after deletion (deleted report no longer visible)
- [ ] Network error during delete -> error message shown, report preserved
- [ ] All unit tests pass (`xcodebuild test -scheme AarogyaiOS-Dev -only-testing:AarogyaiOSTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)