### PR TITLE
feat(profile): implement account deletion request

### DIFF
--- a/AarogyaiOS/Data/Network/APIClient.swift
+++ b/AarogyaiOS/Data/Network/APIClient.swift
@@ -129,10 +129,14 @@ final class APIClient: Sendable {
             }
         case 409:
             let errorResponse = try? decoder.decode(ErrorResponse.self, from: data)
-            if errorResponse?.errorCode == "already_verified" {
+            switch errorResponse?.errorCode {
+            case "already_verified":
                 throw APIError.alreadyVerified
+            case "deletion_already_pending":
+                throw APIError.deletionAlreadyPending
+            default:
+                throw APIError.unknown(status: 409)
             }
-            throw APIError.unknown(status: 409)
         case 429:
             let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
                 .flatMap(TimeInterval.init)

--- a/AarogyaiOS/Data/Network/APIError.swift
+++ b/AarogyaiOS/Data/Network/APIError.swift
@@ -18,6 +18,7 @@ enum APIError: Error, Sendable {
     case alreadyVerified
     case invalidAadhaar
     case aadhaarMismatch
+    case deletionAlreadyPending
 
     var isAuthError: Bool {
         switch self {

--- a/AarogyaiOS/Presentation/Settings/SettingsView.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsView.swift
@@ -46,13 +46,26 @@ struct SettingsView: View {
                     .accessibilityIdentifier(AccessibilityID.Settings.exportFooter)
             }
 
-            Section("Danger Zone") {
+            Section {
                 Button(role: .destructive) {
-                    viewModel.showDeleteConfirmation = true
+                    viewModel.beginAccountDeletion()
                 } label: {
-                    Label("Delete Account", systemImage: "trash")
+                    HStack {
+                        Label("Delete Account", systemImage: "trash")
+                        Spacer()
+                        if viewModel.isDeletingAccount {
+                            ProgressView()
+                                .accessibilityIdentifier(AccessibilityID.Settings.deleteAccountProgress)
+                        }
+                    }
                 }
+                .disabled(viewModel.isDeletingAccount)
                 .accessibilityIdentifier(AccessibilityID.Settings.deleteAccountButton)
+            } header: {
+                Text("Danger Zone")
+            } footer: {
+                Text("Permanently delete your account and all associated data. This cannot be undone.")
+                    .accessibilityIdentifier(AccessibilityID.Settings.deleteAccountFooter)
             }
 
             Section {
@@ -118,13 +131,25 @@ struct SettingsView: View {
         } message: {
             Text("Your data export has been requested. You will be notified when it is ready.")
         }
-        .alert("Delete Account", isPresented: $viewModel.showDeleteConfirmation) {
+        // Step 1: Initial warning alert
+        .alert("Delete Account?", isPresented: $viewModel.showDeleteConfirmation) {
             Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
-                Task { await viewModel.requestAccountDeletion() }
+            Button("Continue", role: .destructive) {
+                viewModel.proceedToDeleteTypingConfirmation()
             }
+            .accessibilityIdentifier(AccessibilityID.Settings.deleteConfirmContinueButton)
         } message: {
-            Text("This action is irreversible. All your data will be permanently deleted.")
+            Text(
+                """
+                This will permanently delete your account, including all \
+                medical records, access grants, and personal data. This \
+                action cannot be undone.
+                """
+            )
+        }
+        // Step 2: Type "DELETE" confirmation sheet
+        .sheet(isPresented: $viewModel.showDeleteTypingConfirmation) {
+            deleteTypingConfirmationSheet
         }
         .alert("Error", isPresented: .constant(viewModel.error != nil)) {
             Button("OK") { viewModel.error = nil }
@@ -133,6 +158,96 @@ struct SettingsView: View {
                 Text(error)
             }
         }
+    }
+
+    // MARK: - Delete Typing Confirmation Sheet
+
+    private var deleteTypingConfirmationSheet: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.red)
+                    .accessibilityIdentifier(AccessibilityID.Settings.deleteWarningIcon)
+
+                Text("Confirm Account Deletion")
+                    .font(Typography.title2)
+
+                Text(
+                    """
+                    To confirm, type \
+                    \(SettingsViewModel.deletionConfirmationKeyword) \
+                    below. This will:
+                    """
+                )
+                .font(Typography.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(
+                        "Delete all your medical records",
+                        systemImage: "doc.fill"
+                    )
+                    Label(
+                        "Revoke all access grants",
+                        systemImage: "person.badge.minus"
+                    )
+                    Label(
+                        "Remove all personal data",
+                        systemImage: "person.crop.circle.badge.xmark"
+                    )
+                    Label(
+                        "Sign you out permanently",
+                        systemImage: "rectangle.portrait.and.arrow.right"
+                    )
+                }
+                .font(Typography.subheadline)
+                .foregroundStyle(.secondary)
+
+                TextField(
+                    "Type \(SettingsViewModel.deletionConfirmationKeyword) to confirm",
+                    text: $viewModel.deleteConfirmationText
+                )
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled()
+                .padding()
+                .background(.fill.tertiary)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .accessibilityIdentifier(AccessibilityID.Settings.deleteConfirmationTextField)
+
+                Button {
+                    Task { await viewModel.confirmAccountDeletion() }
+                } label: {
+                    HStack {
+                        if viewModel.isDeletingAccount {
+                            ProgressView()
+                                .tint(.white)
+                        }
+                        Text("Delete My Account")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .disabled(!viewModel.isDeleteConfirmationValid || viewModel.isDeletingAccount)
+                .accessibilityIdentifier(AccessibilityID.Settings.deleteConfirmFinalButton)
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Delete Account")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        viewModel.cancelAccountDeletion()
+                    }
+                    .accessibilityIdentifier(AccessibilityID.Settings.deleteCancelButton)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
     }
 }
 

--- a/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
@@ -8,7 +8,17 @@ final class SettingsViewModel {
     var exportSuccess = false
     var showExportConfirmation = false
     var error: String?
+
+    // MARK: - Account Deletion State
+
+    /// Step 1: initial warning dialog
     var showDeleteConfirmation = false
+    /// Step 2: type "DELETE" confirmation sheet
+    var showDeleteTypingConfirmation = false
+    /// Text the user types to confirm deletion
+    var deleteConfirmationText = ""
+    /// Whether the deletion request is in progress
+    var isDeletingAccount = false
 
     let getCurrentUserUseCase: GetCurrentUserUseCase
     let updateProfileUseCase: UpdateProfileUseCase
@@ -19,6 +29,9 @@ final class SettingsViewModel {
     private let exportDataUseCase: ExportDataUseCase
     private let requestAccountDeletionUseCase: RequestAccountDeletionUseCase
     private let onSignOut: () async -> Void
+
+    /// The string the user must type to confirm deletion.
+    static let deletionConfirmationKeyword = "DELETE"
 
     init(
         getCurrentUserUseCase: GetCurrentUserUseCase,
@@ -77,14 +90,55 @@ final class SettingsViewModel {
         exportSuccess = false
     }
 
-    func requestAccountDeletion() async {
+    // MARK: - Account Deletion (Multi-Step)
+
+    /// Step 1: User taps "Delete Account" button. Show initial warning.
+    func beginAccountDeletion() {
+        showDeleteConfirmation = true
+    }
+
+    /// Step 1 -> Step 2: User confirmed the initial warning. Show typing confirmation.
+    func proceedToDeleteTypingConfirmation() {
+        deleteConfirmationText = ""
+        showDeleteTypingConfirmation = true
+    }
+
+    /// Whether the typed text matches the confirmation keyword.
+    var isDeleteConfirmationValid: Bool {
+        deleteConfirmationText.trimmingCharacters(in: .whitespaces)
+            .uppercased() == Self.deletionConfirmationKeyword
+    }
+
+    /// Step 2 confirmed: actually request deletion from the backend.
+    func confirmAccountDeletion() async {
+        guard isDeleteConfirmationValid else { return }
+        isDeletingAccount = true
+        error = nil
         do {
             try await requestAccountDeletionUseCase.execute()
+            showDeleteTypingConfirmation = false
+            deleteConfirmationText = ""
+            Logger.data.info("Account deletion requested successfully")
             await signOut()
+        } catch let apiError as APIError {
+            self.error = mapDeletionError(apiError)
+            Logger.data.error("Account deletion failed: \(apiError)")
         } catch {
-            self.error = "Failed to request account deletion"
+            self.error = "Failed to request account deletion. Please try again."
             Logger.data.error("Account deletion failed: \(error)")
         }
+        isDeletingAccount = false
+    }
+
+    /// Cancel the deletion flow and reset state.
+    func cancelAccountDeletion() {
+        showDeleteTypingConfirmation = false
+        deleteConfirmationText = ""
+    }
+
+    /// Legacy method kept for backward compatibility — now routes through multi-step flow.
+    func requestAccountDeletion() async {
+        await confirmAccountDeletion()
     }
 
     // MARK: - Private
@@ -101,6 +155,23 @@ final class SettingsViewModel {
             "Network error. Check your connection and try again."
         default:
             "Failed to export data. Please try again."
+        }
+    }
+
+    private func mapDeletionError(_ apiError: APIError) -> String {
+        switch apiError {
+        case .deletionAlreadyPending:
+            "A deletion request is already pending. Please wait for it to be processed."
+        case .unauthorized, .tokenRefreshFailed:
+            "Session expired. Please sign in again."
+        case .rateLimited:
+            "Too many requests. Please try again later."
+        case .serverError:
+            "Server error. Please try again later."
+        case .networkError:
+            "Network error. Check your connection and try again."
+        default:
+            "Failed to request account deletion. Please try again."
         }
     }
 }

--- a/AarogyaiOS/Utilities/AccessibilityID.swift
+++ b/AarogyaiOS/Utilities/AccessibilityID.swift
@@ -77,6 +77,13 @@ enum AccessibilityID {
         static let exportConfirmButton = "settings.export.confirm"
         static let exportSuccessOKButton = "settings.export.success.ok"
         static let deleteAccountButton = "settings.deleteAccount"
+        static let deleteAccountProgress = "settings.deleteAccount.progress"
+        static let deleteAccountFooter = "settings.deleteAccount.footer"
+        static let deleteConfirmContinueButton = "settings.deleteAccount.confirm.continue"
+        static let deleteWarningIcon = "settings.deleteAccount.warningIcon"
+        static let deleteConfirmationTextField = "settings.deleteAccount.confirmationField"
+        static let deleteConfirmFinalButton = "settings.deleteAccount.confirm.final"
+        static let deleteCancelButton = "settings.deleteAccount.cancel"
         static let signOutButton = "settings.signOut"
         static let versionLabel = "settings.version"
     }

--- a/AarogyaiOSTests/Domain/RequestAccountDeletionUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/RequestAccountDeletionUseCaseTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("RequestAccountDeletionUseCase")
+@MainActor
+struct RequestAccountDeletionUseCaseTests {
+    let userRepo = MockUserRepository()
+
+    func makeSUT() -> RequestAccountDeletionUseCase {
+        RequestAccountDeletionUseCase(userRepository: userRepo)
+    }
+
+    @Test func executeCallsRepository() async throws {
+        let sut = makeSUT()
+        try await sut.execute()
+        #expect(userRepo.requestDeletionCallCount == 1)
+    }
+
+    @Test func executePropagatesServerError() async {
+        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+
+        await #expect(throws: APIError.self) {
+            try await sut.execute()
+        }
+    }
+
+    @Test func executePropagatesNetworkError() async {
+        userRepo.requestDeletionResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let sut = makeSUT()
+
+        await #expect(throws: APIError.self) {
+            try await sut.execute()
+        }
+    }
+
+    @Test func executePropagatesUnauthorizedError() async {
+        userRepo.requestDeletionResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+
+        await #expect(throws: APIError.self) {
+            try await sut.execute()
+        }
+    }
+
+    @Test func executePropagatesDeletionAlreadyPendingError() async {
+        userRepo.requestDeletionResult = .failure(APIError.deletionAlreadyPending)
+        let sut = makeSUT()
+
+        await #expect(throws: APIError.self) {
+            try await sut.execute()
+        }
+    }
+
+    @Test func executePropagatesRateLimitedError() async {
+        userRepo.requestDeletionResult = .failure(APIError.rateLimited(retryAfter: 30))
+        let sut = makeSUT()
+
+        await #expect(throws: APIError.self) {
+            try await sut.execute()
+        }
+    }
+}

--- a/AarogyaiOSTests/Presentation/SettingsViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/SettingsViewModelTests.swift
@@ -140,34 +140,234 @@ struct SettingsViewModelTests {
         #expect(!sut.exportSuccess)
     }
 
-    // MARK: - Account Deletion
+    // MARK: - Account Deletion: Step 1 — Initial Warning
 
-    @Test func requestAccountDeletionCallsRepository() async {
+    @Test func beginAccountDeletionShowsConfirmation() {
         let sut = makeSUT()
+        #expect(!sut.showDeleteConfirmation)
+        sut.beginAccountDeletion()
+        #expect(sut.showDeleteConfirmation)
+    }
+
+    // MARK: - Account Deletion: Step 2 — Typing Confirmation
+
+    @Test func proceedToDeleteTypingConfirmationShowsSheet() {
+        let sut = makeSUT()
+        sut.proceedToDeleteTypingConfirmation()
+        #expect(sut.showDeleteTypingConfirmation)
+        #expect(sut.deleteConfirmationText.isEmpty)
+    }
+
+    @Test func proceedToDeleteTypingConfirmationResetsText() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "something"
+        sut.proceedToDeleteTypingConfirmation()
+        #expect(sut.deleteConfirmationText.isEmpty)
+    }
+
+    @Test func isDeleteConfirmationValidReturnsFalseWhenEmpty() {
+        let sut = makeSUT()
+        #expect(!sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidReturnsFalseForPartialText() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DEL"
+        #expect(!sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidReturnsFalseForWrongText() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "REMOVE"
+        #expect(!sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidReturnsTrueForExactMatch() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        #expect(sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidIsCaseInsensitive() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "delete"
+        #expect(sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidTrimsWhitespace() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "  DELETE  "
+        #expect(sut.isDeleteConfirmationValid)
+    }
+
+    @Test func isDeleteConfirmationValidHandlesMixedCase() {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "Delete"
+        #expect(sut.isDeleteConfirmationValid)
+    }
+
+    // MARK: - Account Deletion: Confirm and Execute
+
+    @Test func confirmAccountDeletionCallsRepository() async {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(userRepo.requestDeletionCallCount == 1)
+    }
+
+    @Test func confirmAccountDeletionDoesNothingWhenTextInvalid() async {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "WRONG"
+        await sut.confirmAccountDeletion()
+        #expect(userRepo.requestDeletionCallCount == 0)
+    }
+
+    @Test func confirmAccountDeletionSignsOutOnSuccess() async {
+        let signedOut = Mutex(false)
+        let sut = makeSUT(signOutCalled: { signedOut.withLock { $0 = true } })
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(signedOut.withLock { $0 })
+    }
+
+    @Test func confirmAccountDeletionClearsSheetOnSuccess() async {
+        let sut = makeSUT()
+        sut.showDeleteTypingConfirmation = true
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(!sut.showDeleteTypingConfirmation)
+        #expect(sut.deleteConfirmationText.isEmpty)
+    }
+
+    @Test func confirmAccountDeletionSetsIsDeletingFalseAfterSuccess() async {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(!sut.isDeletingAccount)
+    }
+
+    @Test func confirmAccountDeletionClearsErrorOnNewAttempt() async {
+        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error != nil)
+
+        userRepo.requestDeletionResult = .success(())
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == nil)
+    }
+
+    // MARK: - Account Deletion: Error Handling
+
+    @Test func confirmAccountDeletionSetsErrorOnFailure() async {
+        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Server error. Please try again later.")
+    }
+
+    @Test func confirmAccountDeletionDoesNotSignOutOnFailure() async {
+        let signedOut = Mutex(false)
+        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT(signOutCalled: { signedOut.withLock { $0 = true } })
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(!signedOut.withLock { $0 })
+    }
+
+    @Test func confirmAccountDeletionSetsIsDeletingFalseAfterFailure() async {
+        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(!sut.isDeletingAccount)
+    }
+
+    @Test func confirmAccountDeletionHandlesDeletionAlreadyPending() async {
+        userRepo.requestDeletionResult = .failure(APIError.deletionAlreadyPending)
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "A deletion request is already pending. Please wait for it to be processed.")
+    }
+
+    @Test func confirmAccountDeletionHandlesUnauthorizedError() async {
+        userRepo.requestDeletionResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func confirmAccountDeletionHandlesTokenRefreshFailed() async {
+        userRepo.requestDeletionResult = .failure(APIError.tokenRefreshFailed)
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func confirmAccountDeletionHandlesRateLimited() async {
+        userRepo.requestDeletionResult = .failure(APIError.rateLimited(retryAfter: 30))
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Too many requests. Please try again later.")
+    }
+
+    @Test func confirmAccountDeletionHandlesNetworkError() async {
+        userRepo.requestDeletionResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Network error. Check your connection and try again.")
+    }
+
+    @Test func confirmAccountDeletionHandlesUnknownAPIError() async {
+        userRepo.requestDeletionResult = .failure(APIError.unknown(status: 418))
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Failed to request account deletion. Please try again.")
+    }
+
+    @Test func confirmAccountDeletionHandlesNonAPIError() async {
+        struct CustomError: Error {}
+        userRepo.requestDeletionResult = .failure(CustomError())
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
+        await sut.confirmAccountDeletion()
+        #expect(sut.error == "Failed to request account deletion. Please try again.")
+    }
+
+    // MARK: - Account Deletion: Cancel
+
+    @Test func cancelAccountDeletionResetsState() {
+        let sut = makeSUT()
+        sut.showDeleteTypingConfirmation = true
+        sut.deleteConfirmationText = "DELE"
+        sut.cancelAccountDeletion()
+        #expect(!sut.showDeleteTypingConfirmation)
+        #expect(sut.deleteConfirmationText.isEmpty)
+    }
+
+    // MARK: - Account Deletion: Legacy Method
+
+    @Test func requestAccountDeletionCallsConfirmAccountDeletion() async {
+        let sut = makeSUT()
+        sut.deleteConfirmationText = "DELETE"
         await sut.requestAccountDeletion()
         #expect(userRepo.requestDeletionCallCount == 1)
     }
 
-    @Test func requestAccountDeletionSignsOutOnSuccess() async {
-        let signedOut = Mutex(false)
-        let sut = makeSUT(signOutCalled: { signedOut.withLock { $0 = true } })
-        await sut.requestAccountDeletion()
-        #expect(signedOut.withLock { $0 })
-    }
+    // MARK: - Account Deletion: Confirmation Keyword
 
-    @Test func requestAccountDeletionSetsErrorOnFailure() async {
-        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
-        let sut = makeSUT()
-        await sut.requestAccountDeletion()
-        #expect(sut.error == "Failed to request account deletion")
-    }
-
-    @Test func requestAccountDeletionDoesNotSignOutOnFailure() async {
-        let signedOut = Mutex(false)
-        userRepo.requestDeletionResult = .failure(APIError.serverError(status: 500))
-        let sut = makeSUT(signOutCalled: { signedOut.withLock { $0 = true } })
-        await sut.requestAccountDeletion()
-        #expect(!signedOut.withLock { $0 })
+    @Test func deletionConfirmationKeywordIsDELETE() {
+        #expect(SettingsViewModel.deletionConfirmationKeyword == "DELETE")
     }
 
     // MARK: - Sign Out


### PR DESCRIPTION
## Summary
- Add multi-step account deletion flow to Settings: initial warning alert (step 1) followed by a confirmation sheet requiring user to type "DELETE" (step 2)
- Handle `deletionAlreadyPending` (409) API error with user-friendly message
- Clear Keychain tokens, sign out, and navigate to login on successful deletion

Closes #104

## Test plan
- [ ] Verify "Delete Account" button in Settings shows initial warning alert
- [ ] Verify "Continue" on warning alert opens typing confirmation sheet
- [ ] Verify "Delete My Account" button is disabled until "DELETE" is typed
- [ ] Verify case-insensitive match works (e.g., "delete", "Delete")
- [ ] Verify successful deletion clears auth state and navigates to login
- [ ] Verify already-pending deletion shows appropriate error message
- [ ] Verify cancel button on confirmation sheet resets state
- [ ] Verify network/server errors show appropriate messages
- [ ] Verify loading spinner appears during deletion request
- [ ] Run `xcodebuild test` — all 175+ tests pass with 100% coverage on SettingsViewModel

🤖 Generated with [Claude Code](https://claude.com/claude-code)