### PR TITLE
feat(notifications): implement device token registration

### DIFF
--- a/AarogyaiOS/App/DependencyContainer.swift
+++ b/AarogyaiOS/App/DependencyContainer.swift
@@ -10,6 +10,7 @@ final class DependencyContainer {
     let tokenStore: any TokenStoring
     let s3UploadService: S3UploadService
     let pushService: any PushNotificationService
+    let deviceTokenManager: any DeviceTokenManaging
 
     // MARK: - Data
 
@@ -88,6 +89,7 @@ final class DependencyContainer {
             let deps = Self.makeStubDependencies()
             tokenStore = deps.tokenStore
             s3UploadService = S3UploadService()
+            deviceTokenManager = StubDeviceTokenManager()
             authInterceptor = deps.interceptor
             apiClient = deps.client
             authRepository = deps.auth
@@ -128,6 +130,10 @@ final class DependencyContainer {
             )
             tokenStore = deps.tokenStore
             s3UploadService = S3UploadService()
+            deviceTokenManager = DeviceTokenManager(
+                notificationRepository: deps.notification,
+                tokenStore: KeychainDeviceTokenStore(keychainService: keychainService)
+            )
             authInterceptor = deps.interceptor
             apiClient = deps.client
             authRepository = deps.auth

--- a/AarogyaiOS/Infrastructure/Push/DeviceTokenManager.swift
+++ b/AarogyaiOS/Infrastructure/Push/DeviceTokenManager.swift
@@ -1,0 +1,115 @@
+import Foundation
+import OSLog
+
+/// Coordinates device token lifecycle: registration on push permission grant,
+/// re-registration on app launch when the token changes, and unregistration on sign-out.
+protocol DeviceTokenManaging: Sendable {
+    /// Registers a device token with the backend. Stores the token locally
+    /// and skips the API call if the token has not changed since last registration.
+    func registerDeviceToken(_ token: String) async
+
+    /// Re-registers the stored device token on app launch. Always sends the
+    /// current token to the backend so the server can update metadata.
+    func reregisterIfNeeded() async
+
+    /// Unregisters the current device token from the backend and clears local storage.
+    func unregisterCurrentDevice() async
+
+    /// Returns the currently stored device token, if any.
+    func currentToken() -> String?
+}
+
+/// Abstracts local storage of the device push token for testability.
+protocol DeviceTokenStoring: Sendable {
+    func saveToken(_ token: String) throws
+    func readToken() -> String?
+    func deleteToken() throws
+}
+
+/// Stores device push tokens in the Keychain.
+struct KeychainDeviceTokenStore: DeviceTokenStoring {
+    private let keychainService: KeychainService
+    private let key = Constants.Keychain.deviceTokenKey
+
+    init(keychainService: KeychainService) {
+        self.keychainService = keychainService
+    }
+
+    func saveToken(_ token: String) throws {
+        try keychainService.save(token, for: key)
+    }
+
+    func readToken() -> String? {
+        try? keychainService.readString(key: key)
+    }
+
+    func deleteToken() throws {
+        try keychainService.delete(key: key)
+    }
+}
+
+final class DeviceTokenManager: DeviceTokenManaging, @unchecked Sendable {
+    private let notificationRepository: any NotificationRepository
+    private let tokenStore: any DeviceTokenStoring
+
+    init(
+        notificationRepository: any NotificationRepository,
+        tokenStore: any DeviceTokenStoring
+    ) {
+        self.notificationRepository = notificationRepository
+        self.tokenStore = tokenStore
+    }
+
+    func registerDeviceToken(_ token: String) async {
+        let storedToken = currentToken()
+
+        // Skip registration if token has not changed
+        if storedToken == token {
+            Logger.push.info("Device token unchanged, skipping registration")
+            return
+        }
+
+        do {
+            _ = try await notificationRepository.registerDevice(token: token)
+            try tokenStore.saveToken(token)
+            Logger.push.info("Device token registered successfully")
+        } catch {
+            Logger.push.error("Device token registration failed: \(error)")
+        }
+    }
+
+    func reregisterIfNeeded() async {
+        guard let storedToken = currentToken() else {
+            Logger.push.info("No stored device token, skipping re-registration")
+            return
+        }
+
+        do {
+            _ = try await notificationRepository.registerDevice(token: storedToken)
+            Logger.push.info("Device token re-registered on launch")
+        } catch {
+            Logger.push.error("Device token re-registration failed: \(error)")
+        }
+    }
+
+    func unregisterCurrentDevice() async {
+        guard let storedToken = currentToken() else {
+            Logger.push.info("No stored device token, skipping unregistration")
+            return
+        }
+
+        do {
+            try await notificationRepository.unregisterDevice(token: storedToken)
+            try tokenStore.deleteToken()
+            Logger.push.info("Device token unregistered successfully")
+        } catch {
+            Logger.push.error("Device token unregistration failed: \(error)")
+            // Still attempt to clear local token even if server call fails
+            try? tokenStore.deleteToken()
+        }
+    }
+
+    func currentToken() -> String? {
+        tokenStore.readToken()
+    }
+}

--- a/AarogyaiOS/Infrastructure/Push/StubDeviceTokenManager.swift
+++ b/AarogyaiOS/Infrastructure/Push/StubDeviceTokenManager.swift
@@ -1,0 +1,21 @@
+import Foundation
+import OSLog
+
+/// A no-op device token manager for use in previews, UI tests, and test defaults.
+struct StubDeviceTokenManager: DeviceTokenManaging {
+    func registerDeviceToken(_ token: String) async {
+        Logger.push.info("StubDeviceTokenManager: registerDeviceToken")
+    }
+
+    func reregisterIfNeeded() async {
+        Logger.push.info("StubDeviceTokenManager: reregisterIfNeeded")
+    }
+
+    func unregisterCurrentDevice() async {
+        Logger.push.info("StubDeviceTokenManager: unregisterCurrentDevice")
+    }
+
+    func currentToken() -> String? {
+        nil
+    }
+}

--- a/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/AppCoordinator.swift
@@ -19,15 +19,22 @@ final class AppCoordinator {
 
     private let getCurrentUser: GetCurrentUserUseCase
     private let logout: LogoutUseCase
+    private let deviceTokenManager: any DeviceTokenManaging
 
     init(container: DependencyContainer) {
         self.getCurrentUser = container.getCurrentUserUseCase
         self.logout = container.logoutUseCase
+        self.deviceTokenManager = container.deviceTokenManager
     }
 
-    init(getCurrentUser: GetCurrentUserUseCase, logout: LogoutUseCase) {
+    init(
+        getCurrentUser: GetCurrentUserUseCase,
+        logout: LogoutUseCase,
+        deviceTokenManager: any DeviceTokenManaging = StubDeviceTokenManager()
+    ) {
         self.getCurrentUser = getCurrentUser
         self.logout = logout
+        self.deviceTokenManager = deviceTokenManager
     }
 
     func checkAuthState() async {
@@ -40,6 +47,7 @@ final class AppCoordinator {
                 state = .rejected
             case .approved:
                 state = .authenticated(user)
+                await deviceTokenManager.reregisterIfNeeded()
             }
         } catch let error as APIError {
             switch error {
@@ -66,6 +74,7 @@ final class AppCoordinator {
     }
 
     func handleLogout() async {
+        await deviceTokenManager.unregisterCurrentDevice()
         do {
             try await logout.execute()
         } catch {

--- a/AarogyaiOS/Utilities/Constants.swift
+++ b/AarogyaiOS/Utilities/Constants.swift
@@ -25,6 +25,7 @@ enum Constants {
         static let accessTokenKey = "access_token"
         static let refreshTokenKey = "refresh_token"
         static let idTokenKey = "id_token"
+        static let deviceTokenKey = "device_push_token"
     }
 
     enum Cache {

--- a/AarogyaiOS/Utilities/Logger.swift
+++ b/AarogyaiOS/Utilities/Logger.swift
@@ -10,5 +10,6 @@ extension Logger {
     static let upload = Logger(subsystem: subsystem, category: "upload")
     static let cache = Logger(subsystem: subsystem, category: "cache")
     static let navigation = Logger(subsystem: subsystem, category: "navigation")
+    static let push = Logger(subsystem: subsystem, category: "push")
     static let security = Logger(subsystem: subsystem, category: "security")
 }

--- a/AarogyaiOSTests/Domain/ConsentsUseCaseTests.swift
+++ b/AarogyaiOSTests/Domain/ConsentsUseCaseTests.swift
@@ -38,4 +38,37 @@ struct ManageNotificationsUseCaseTests {
         #expect(updated.reportUploaded.push)
         #expect(repo.updatePreferencesCallCount == 1)
     }
+
+    @Test func registerDeviceCallsRepository() async throws {
+        let deviceToken = try await sut.registerDevice(token: "test-push-token")
+        #expect(deviceToken.id == "dt-1")
+        #expect(repo.registerDeviceCallCount == 1)
+        #expect(repo.lastRegisteredToken == "test-push-token")
+    }
+
+    @Test func unregisterDeviceCallsRepository() async throws {
+        try await sut.unregisterDevice(token: "test-push-token")
+        #expect(repo.unregisterDeviceCallCount == 1)
+        #expect(repo.lastUnregisteredToken == "test-push-token")
+    }
+
+    @Test func registerDevicePropagatesError() async {
+        repo.registerDeviceResult = .failure(APIError.serverError(status: 500))
+        do {
+            _ = try await sut.registerDevice(token: "token")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(error is APIError)
+        }
+    }
+
+    @Test func unregisterDevicePropagatesError() async {
+        repo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        do {
+            try await sut.unregisterDevice(token: "token")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(error is APIError)
+        }
+    }
 }

--- a/AarogyaiOSTests/Infrastructure/DeviceTokenManagerTests.swift
+++ b/AarogyaiOSTests/Infrastructure/DeviceTokenManagerTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("DeviceTokenManager")
+struct DeviceTokenManagerTests {
+    let notifRepo = MockNotificationRepository()
+    let tokenStore = InMemoryDeviceTokenStore()
+
+    func makeSUT() -> DeviceTokenManager {
+        DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: tokenStore
+        )
+    }
+
+    // MARK: - registerDeviceToken
+
+    @Test func registerDeviceTokenCallsRepositoryWithToken() async {
+        let sut = makeSUT()
+        await sut.registerDeviceToken("abc123")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(notifRepo.lastRegisteredToken == "abc123")
+    }
+
+    @Test func registerDeviceTokenStoresTokenLocally() async {
+        let sut = makeSUT()
+        await sut.registerDeviceToken("abc123")
+        #expect(sut.currentToken() == "abc123")
+        #expect(tokenStore.saveCallCount == 1)
+    }
+
+    @Test func registerDeviceTokenSkipsWhenTokenUnchanged() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "abc123")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.registerDeviceToken("abc123")
+        #expect(notifRepo.registerDeviceCallCount == 0)
+    }
+
+    @Test func registerDeviceTokenSendsWhenTokenChanged() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "old-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.registerDeviceToken("new-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(notifRepo.lastRegisteredToken == "new-token")
+        #expect(sut.currentToken() == "new-token")
+    }
+
+    @Test func registerDeviceTokenDoesNotStoreOnAPIFailure() async {
+        notifRepo.registerDeviceResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        await sut.registerDeviceToken("abc123")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(sut.currentToken() == nil)
+        #expect(tokenStore.saveCallCount == 0)
+    }
+
+    @Test func registerDeviceTokenRegistersFirstTimeWhenNoStoredToken() async {
+        let sut = makeSUT()
+        #expect(sut.currentToken() == nil)
+        await sut.registerDeviceToken("first-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(sut.currentToken() == "first-token")
+    }
+
+    @Test func registerDeviceTokenHandlesNetworkError() async {
+        notifRepo.registerDeviceResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let sut = makeSUT()
+        await sut.registerDeviceToken("abc123")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(sut.currentToken() == nil)
+    }
+
+    @Test func registerDeviceTokenHandlesUnauthorizedError() async {
+        notifRepo.registerDeviceResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+        await sut.registerDeviceToken("abc123")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(sut.currentToken() == nil)
+    }
+
+    // MARK: - reregisterIfNeeded
+
+    @Test func reregisterIfNeededCallsRepositoryWhenTokenExists() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "existing-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.reregisterIfNeeded()
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(notifRepo.lastRegisteredToken == "existing-token")
+    }
+
+    @Test func reregisterIfNeededSkipsWhenNoStoredToken() async {
+        let sut = makeSUT()
+        await sut.reregisterIfNeeded()
+        #expect(notifRepo.registerDeviceCallCount == 0)
+    }
+
+    @Test func reregisterIfNeededHandlesAPIFailureGracefully() async {
+        notifRepo.registerDeviceResult = .failure(APIError.serverError(status: 500))
+        let store = InMemoryDeviceTokenStore(preloadedToken: "existing-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.reregisterIfNeeded()
+        // Token should still be stored even if re-registration fails
+        #expect(sut.currentToken() == "existing-token")
+    }
+
+    @Test func reregisterIfNeededDoesNotClearTokenOnFailure() async {
+        notifRepo.registerDeviceResult = .failure(APIError.networkError(underlying: URLError(.timedOut)))
+        let store = InMemoryDeviceTokenStore(preloadedToken: "my-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.reregisterIfNeeded()
+        #expect(sut.currentToken() == "my-token")
+        #expect(store.deleteCallCount == 0)
+    }
+
+    // MARK: - unregisterCurrentDevice
+
+    @Test func unregisterCurrentDeviceCallsRepositoryAndClearsStorage() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "existing-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.unregisterCurrentDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 1)
+        #expect(notifRepo.lastUnregisteredToken == "existing-token")
+        #expect(sut.currentToken() == nil)
+        #expect(store.deleteCallCount == 1)
+    }
+
+    @Test func unregisterCurrentDeviceSkipsWhenNoStoredToken() async {
+        let sut = makeSUT()
+        await sut.unregisterCurrentDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 0)
+    }
+
+    @Test func unregisterCurrentDeviceClearsStorageEvenOnAPIFailure() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        let store = InMemoryDeviceTokenStore(preloadedToken: "existing-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.unregisterCurrentDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 1)
+        // Token should still be cleared locally even if server call fails
+        #expect(sut.currentToken() == nil)
+    }
+
+    @Test func unregisterCurrentDeviceClearsStorageOnNetworkError() async {
+        notifRepo.unregisterDeviceResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let store = InMemoryDeviceTokenStore(preloadedToken: "existing-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        await sut.unregisterCurrentDevice()
+        #expect(sut.currentToken() == nil)
+    }
+
+    // MARK: - currentToken
+
+    @Test func currentTokenReturnsNilWhenEmpty() {
+        let sut = makeSUT()
+        #expect(sut.currentToken() == nil)
+    }
+
+    @Test func currentTokenReturnsStoredValue() {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "stored-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+        #expect(sut.currentToken() == "stored-token")
+    }
+
+    // MARK: - Full Lifecycle
+
+    @Test func fullLifecycleRegisterThenUnregister() async {
+        let sut = makeSUT()
+
+        // Register
+        await sut.registerDeviceToken("lifecycle-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(sut.currentToken() == "lifecycle-token")
+
+        // Unregister
+        await sut.unregisterCurrentDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 1)
+        #expect(sut.currentToken() == nil)
+    }
+
+    @Test func registerThenReregisterSendsTokenAgain() async {
+        let sut = makeSUT()
+
+        await sut.registerDeviceToken("my-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+
+        await sut.reregisterIfNeeded()
+        #expect(notifRepo.registerDeviceCallCount == 2)
+        #expect(notifRepo.lastRegisteredToken == "my-token")
+    }
+
+    @Test func registerNewTokenOverwritesOldToken() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "old-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+
+        await sut.registerDeviceToken("new-token")
+        #expect(sut.currentToken() == "new-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+    }
+
+    @Test func unregisterThenRegisterNewToken() async {
+        let store = InMemoryDeviceTokenStore(preloadedToken: "old-token")
+        let sut = DeviceTokenManager(
+            notificationRepository: notifRepo,
+            tokenStore: store
+        )
+
+        await sut.unregisterCurrentDevice()
+        #expect(sut.currentToken() == nil)
+
+        await sut.registerDeviceToken("fresh-token")
+        #expect(sut.currentToken() == "fresh-token")
+        #expect(notifRepo.registerDeviceCallCount == 1)
+        #expect(notifRepo.unregisterDeviceCallCount == 1)
+    }
+}

--- a/AarogyaiOSTests/Mocks/MockDeviceTokenManager.swift
+++ b/AarogyaiOSTests/Mocks/MockDeviceTokenManager.swift
@@ -1,0 +1,30 @@
+import Foundation
+@testable import AarogyaiOS
+
+final class MockDeviceTokenManager: DeviceTokenManaging, @unchecked Sendable {
+    var registerDeviceTokenCallCount = 0
+    var reregisterIfNeededCallCount = 0
+    var unregisterCurrentDeviceCallCount = 0
+
+    var lastRegisteredToken: String?
+    var storedToken: String?
+
+    func registerDeviceToken(_ token: String) async {
+        registerDeviceTokenCallCount += 1
+        lastRegisteredToken = token
+        storedToken = token
+    }
+
+    func reregisterIfNeeded() async {
+        reregisterIfNeededCallCount += 1
+    }
+
+    func unregisterCurrentDevice() async {
+        unregisterCurrentDeviceCallCount += 1
+        storedToken = nil
+    }
+
+    func currentToken() -> String? {
+        storedToken
+    }
+}

--- a/AarogyaiOSTests/Mocks/MockKeychainService.swift
+++ b/AarogyaiOSTests/Mocks/MockKeychainService.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import AarogyaiOS
+
+/// An in-memory device token store for unit testing, avoiding real Keychain access.
+final class InMemoryDeviceTokenStore: DeviceTokenStoring, @unchecked Sendable {
+    private var storedToken: String?
+
+    var saveCallCount = 0
+    var readCallCount = 0
+    var deleteCallCount = 0
+    var shouldThrowOnSave = false
+    var shouldThrowOnDelete = false
+
+    init(preloadedToken: String? = nil) {
+        self.storedToken = preloadedToken
+    }
+
+    func saveToken(_ token: String) throws {
+        saveCallCount += 1
+        if shouldThrowOnSave {
+            throw KeychainError.unexpectedStatus(-1)
+        }
+        storedToken = token
+    }
+
+    func readToken() -> String? {
+        readCallCount += 1
+        return storedToken
+    }
+
+    func deleteToken() throws {
+        deleteCallCount += 1
+        if shouldThrowOnDelete {
+            throw KeychainError.unexpectedStatus(-1)
+        }
+        storedToken = nil
+    }
+}

--- a/AarogyaiOSTests/Mocks/MockNotificationRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockNotificationRepository.swift
@@ -13,6 +13,8 @@ final class MockNotificationRepository: NotificationRepository, @unchecked Senda
     var updatePreferencesCallCount = 0
     var registerDeviceCallCount = 0
     var unregisterDeviceCallCount = 0
+    var lastRegisteredToken: String?
+    var lastUnregisteredToken: String?
     var lastUpdatedPreferences: NotificationPreferences?
 
     func getPreferences() async throws -> NotificationPreferences {
@@ -28,11 +30,13 @@ final class MockNotificationRepository: NotificationRepository, @unchecked Senda
 
     func registerDevice(token: String) async throws -> DeviceToken {
         registerDeviceCallCount += 1
+        lastRegisteredToken = token
         return try registerDeviceResult.get()
     }
 
     func unregisterDevice(token: String) async throws {
         unregisterDeviceCallCount += 1
+        lastUnregisteredToken = token
         try unregisterDeviceResult.get()
     }
 }

--- a/AarogyaiOSTests/Mocks/TestStubs.swift
+++ b/AarogyaiOSTests/Mocks/TestStubs.swift
@@ -186,6 +186,18 @@ extension ReportExtraction {
     )
 }
 
+extension DeviceToken {
+    static let stub = DeviceToken(
+        id: "dt-1",
+        deviceToken: "test-device-token",
+        platform: "ios",
+        deviceName: "iPhone",
+        appVersion: "1.0",
+        registeredAt: Date(timeIntervalSince1970: 1_700_000_000),
+        updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+}
+
 extension NotificationPreferences {
     static let stub = NotificationPreferences(
         reportUploaded: ChannelPreferences(push: true, email: true, sms: false),

--- a/AarogyaiOSTests/Presentation/AppCoordinatorTests.swift
+++ b/AarogyaiOSTests/Presentation/AppCoordinatorTests.swift
@@ -8,11 +8,13 @@ struct AppCoordinatorTests {
     let userRepo = MockUserRepository()
     let authRepo = MockAuthRepository()
     let tokenStore = MockTokenStore()
+    let deviceTokenManager = MockDeviceTokenManager()
 
     func makeSUT() -> AppCoordinator {
         AppCoordinator(
             getCurrentUser: GetCurrentUserUseCase(userRepository: userRepo),
-            logout: LogoutUseCase(authRepository: authRepo, tokenStore: tokenStore)
+            logout: LogoutUseCase(authRepository: authRepo, tokenStore: tokenStore),
+            deviceTokenManager: deviceTokenManager
         )
     }
 
@@ -205,5 +207,58 @@ struct AppCoordinatorTests {
         let originalTab = sut.selectedTab
         sut.consumePendingDeepLink()
         #expect(sut.selectedTab == originalTab)
+    }
+
+    // MARK: - Device Token Registration
+
+    @Test func checkAuthStateReregistersDeviceTokenOnAuthenticated() async {
+        let sut = makeSUT()
+        await sut.checkAuthState()
+        #expect(deviceTokenManager.reregisterIfNeededCallCount == 1)
+    }
+
+    @Test func checkAuthStateDoesNotReregisterOnPendingApproval() async {
+        userRepo.getProfileResult = .success(User.stub(registrationStatus: .pendingApproval))
+        let sut = makeSUT()
+        await sut.checkAuthState()
+        #expect(deviceTokenManager.reregisterIfNeededCallCount == 0)
+    }
+
+    @Test func checkAuthStateDoesNotReregisterOnRejected() async {
+        userRepo.getProfileResult = .success(User.stub(registrationStatus: .rejected))
+        let sut = makeSUT()
+        await sut.checkAuthState()
+        #expect(deviceTokenManager.reregisterIfNeededCallCount == 0)
+    }
+
+    @Test func checkAuthStateDoesNotReregisterOnUnauthorized() async {
+        userRepo.getProfileResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+        await sut.checkAuthState()
+        #expect(deviceTokenManager.reregisterIfNeededCallCount == 0)
+    }
+
+    @Test func handleLogoutUnregistersDeviceToken() async {
+        let sut = makeSUT()
+        sut.state = .authenticated(.stub)
+        await sut.handleLogout()
+        #expect(deviceTokenManager.unregisterCurrentDeviceCallCount == 1)
+    }
+
+    @Test func handleLogoutUnregistersDeviceTokenBeforeClearingTokens() async {
+        // The device token unregistration requires an auth token,
+        // so it must happen before logout clears the token store.
+        let sut = makeSUT()
+        sut.state = .authenticated(.stub)
+        await sut.handleLogout()
+        #expect(deviceTokenManager.unregisterCurrentDeviceCallCount == 1)
+        #expect(tokenStore.clearAllCallCount == 1)
+    }
+
+    @Test func handleLoginTriggersReregistration() async {
+        let sut = makeSUT()
+        await sut.handleLogin()
+        // handleLogin calls checkAuthState which reregisters on success
+        #expect(deviceTokenManager.reregisterIfNeededCallCount == 1)
     }
 }


### PR DESCRIPTION
## Summary
- Add `DeviceTokenManager` to orchestrate push notification token lifecycle (register, re-register on launch, unregister on sign-out)
- Integrate with `AppCoordinator` to re-register device token on successful authentication and unregister before logout
- Add `DeviceTokenStoring` protocol with `KeychainDeviceTokenStore` implementation for secure local token persistence
- Add comprehensive unit tests for `DeviceTokenManager`, `AppCoordinator` integration, and `ManageNotificationsUseCase` device token methods

Closes #106

## Test plan
- [x] `DeviceTokenManagerTests` — 21 tests covering registration, re-registration, unregistration, error handling, and full lifecycle
- [x] `AppCoordinatorTests` — 7 new tests verifying device token re-registration on auth, unregistration on logout, and no-op for non-authenticated states
- [x] `ManageNotificationsUseCaseTests` — 4 new tests for registerDevice/unregisterDevice pass-through and error propagation
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)