### PR TITLE
feat(notifications): implement registered devices list

### DIFF
--- a/AarogyaiOS/App/UITestingStubs.swift
+++ b/AarogyaiOS/App/UITestingStubs.swift
@@ -312,6 +312,7 @@ final class StubNotificationRepository: NotificationRepository, @unchecked Senda
     }
 
     func unregisterDevice(token: String) async throws {}
+    func listDevices() async throws -> [DeviceToken] { [] }
 }
 
 // MARK: - Stub File Uploader

--- a/AarogyaiOS/Data/Network/APIEndpoint.swift
+++ b/AarogyaiOS/Data/Network/APIEndpoint.swift
@@ -54,6 +54,7 @@ enum APIEndpoint: Sendable {
     case updateNotificationPreferences
     case registerDevice
     case unregisterDevice(token: String)
+    case devicesList
 
     var method: HTTPMethod {
         switch self {
@@ -124,7 +125,7 @@ enum APIEndpoint: Sendable {
         // Notifications
         case .notificationPreferences, .updateNotificationPreferences:
             "/api/v1/notifications/preferences"
-        case .registerDevice: "/api/v1/notifications/devices"
+        case .registerDevice, .devicesList: "/api/v1/notifications/devices"
         case .unregisterDevice(let token): "/api/v1/notifications/devices/\(token)"
         }
     }

--- a/AarogyaiOS/Data/Repositories/DefaultNotificationRepository.swift
+++ b/AarogyaiOS/Data/Repositories/DefaultNotificationRepository.swift
@@ -59,6 +59,21 @@ struct DefaultNotificationRepository: NotificationRepository {
         try await apiClient.requestNoContent(.unregisterDevice(token: token))
     }
 
+    func listDevices() async throws -> [DeviceToken] {
+        let responses: [DeviceTokenResponse] = try await apiClient.request(.devicesList)
+        return responses.map { response in
+            DeviceToken(
+                id: response.id,
+                deviceToken: response.deviceToken,
+                platform: response.platform,
+                deviceName: response.deviceName,
+                appVersion: response.appVersion,
+                registeredAt: Date(iso8601: response.registeredAt) ?? .now,
+                updatedAt: Date(iso8601: response.updatedAt) ?? .now
+            )
+        }
+    }
+
     private func toDomain(_ dto: ChannelPreferencesDTO) -> ChannelPreferences {
         ChannelPreferences(push: dto.push, email: dto.email, sms: dto.sms)
     }

--- a/AarogyaiOS/Domain/Repositories/NotificationRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/NotificationRepository.swift
@@ -5,4 +5,5 @@ protocol NotificationRepository: Sendable {
     func updatePreferences(_ preferences: NotificationPreferences) async throws -> NotificationPreferences
     func registerDevice(token: String) async throws -> DeviceToken
     func unregisterDevice(token: String) async throws
+    func listDevices() async throws -> [DeviceToken]
 }

--- a/AarogyaiOS/Domain/UseCases/Notifications/ManageNotificationsUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Notifications/ManageNotificationsUseCase.swift
@@ -22,4 +22,8 @@ struct ManageNotificationsUseCase: Sendable {
     func unregisterDevice(token: String) async throws {
         try await notificationRepository.unregisterDevice(token: token)
     }
+
+    func listDevices() async throws -> [DeviceToken] {
+        try await notificationRepository.listDevices()
+    }
 }

--- a/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
+++ b/AarogyaiOS/Presentation/Navigation/TabCoordinator.swift
@@ -75,6 +75,7 @@ struct TabCoordinator: View {
                         verifyAadhaarUseCase: container.verifyAadhaarUseCase,
                         manageConsentsUseCase: container.manageConsentsUseCase,
                         manageNotificationsUseCase: container.manageNotificationsUseCase,
+                        deviceTokenManager: container.deviceTokenManager,
                         logoutUseCase: container.logoutUseCase,
                         exportDataUseCase: container.exportDataUseCase,
                         requestAccountDeletionUseCase: container.requestAccountDeletionUseCase,

--- a/AarogyaiOS/Presentation/Settings/RegisteredDevicesView.swift
+++ b/AarogyaiOS/Presentation/Settings/RegisteredDevicesView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct RegisteredDevicesView: View {
+    @State var viewModel: RegisteredDevicesViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                LoadingView("Loading devices...")
+                    .accessibilityIdentifier(AccessibilityID.RegisteredDevices.loadingView)
+            } else if viewModel.devices.isEmpty {
+                emptyState
+            } else {
+                devicesList
+            }
+        }
+        .navigationTitle("Registered Devices")
+        .task { await viewModel.loadDevices() }
+        .alert("Error", isPresented: .constant(viewModel.error != nil)) {
+            Button("OK") { viewModel.dismissError() }
+        } message: {
+            if let error = viewModel.error {
+                Text(error)
+            }
+        }
+        .alert(
+            "Deregister Device?",
+            isPresented: $viewModel.showDeregisterConfirmation
+        ) {
+            Button("Cancel", role: .cancel) {
+                viewModel.cancelDeregister()
+            }
+            Button("Deregister", role: .destructive) {
+                Task { await viewModel.deregisterDevice() }
+            }
+            .accessibilityIdentifier(AccessibilityID.RegisteredDevices.deregisterConfirmButton)
+        } message: {
+            if let device = viewModel.deviceToDeregister {
+                Text(
+                    """
+                    This will stop push notifications on \
+                    \(device.deviceName). You can re-register by \
+                    signing in again on that device.
+                    """
+                )
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Registered Devices",
+            systemImage: "laptopcomputer.and.iphone",
+            description: Text("No devices are registered for push notifications.")
+        )
+        .accessibilityIdentifier(AccessibilityID.RegisteredDevices.emptyState)
+    }
+
+    // MARK: - Devices List
+
+    private var devicesList: some View {
+        List {
+            Section {
+                ForEach(viewModel.devices) { device in
+                    deviceRow(device)
+                        .accessibilityIdentifier(
+                            AccessibilityID.RegisteredDevices.deviceRow(device.id)
+                        )
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                viewModel.confirmDeregister(device)
+                            } label: {
+                                Label("Deregister", systemImage: "trash")
+                            }
+                            .accessibilityIdentifier(
+                                AccessibilityID.RegisteredDevices.deregisterButton(device.id)
+                            )
+                        }
+                }
+            } header: {
+                Text("Devices")
+            } footer: {
+                Text("Swipe left on a device to deregister it from receiving push notifications.")
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.RegisteredDevices.list)
+    }
+
+    // MARK: - Device Row
+
+    private func deviceRow(_ device: DeviceToken) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: platformIcon(device.platform))
+                .font(.title2)
+                .foregroundStyle(.tint)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(device.deviceName)
+                        .font(Typography.headline)
+
+                    if viewModel.isCurrentDevice(device) {
+                        Text("This Device")
+                            .font(Typography.caption)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.tint, in: Capsule())
+                            .accessibilityIdentifier(
+                                AccessibilityID.RegisteredDevices.currentBadge(device.id)
+                            )
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    Label(device.platform.capitalized, systemImage: "cpu")
+                    Label("v\(device.appVersion)", systemImage: "app.badge")
+                }
+                .font(Typography.caption)
+                .foregroundStyle(.secondary)
+
+                Text("Registered \(device.registeredAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(Typography.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Helpers
+
+    private func platformIcon(_ platform: String) -> String {
+        switch platform.lowercased() {
+        case "ios": "iphone"
+        case "android": "phone"
+        case "web": "globe"
+        default: "desktopcomputer"
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/RegisteredDevicesViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/RegisteredDevicesViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import OSLog
+
+@Observable
+@MainActor
+final class RegisteredDevicesViewModel {
+    var devices: [DeviceToken] = []
+    var isLoading = false
+    var error: String?
+    var deviceToDeregister: DeviceToken?
+    var showDeregisterConfirmation = false
+    var isDeregistering = false
+
+    private let manageNotificationsUseCase: ManageNotificationsUseCase
+    private let deviceTokenManager: any DeviceTokenManaging
+
+    init(
+        manageNotificationsUseCase: ManageNotificationsUseCase,
+        deviceTokenManager: any DeviceTokenManaging
+    ) {
+        self.manageNotificationsUseCase = manageNotificationsUseCase
+        self.deviceTokenManager = deviceTokenManager
+    }
+
+    var currentDeviceToken: String? {
+        deviceTokenManager.currentToken()
+    }
+
+    func isCurrentDevice(_ device: DeviceToken) -> Bool {
+        guard let currentToken = currentDeviceToken else { return false }
+        return device.deviceToken == currentToken
+    }
+
+    func loadDevices() async {
+        isLoading = true
+        error = nil
+        do {
+            devices = try await manageNotificationsUseCase.listDevices()
+        } catch {
+            self.error = mapError(error, fallback: "Failed to load registered devices")
+            Logger.data.error("Load devices failed: \(error)")
+        }
+        isLoading = false
+    }
+
+    func confirmDeregister(_ device: DeviceToken) {
+        deviceToDeregister = device
+        showDeregisterConfirmation = true
+    }
+
+    func cancelDeregister() {
+        deviceToDeregister = nil
+        showDeregisterConfirmation = false
+    }
+
+    func deregisterDevice() async {
+        guard let device = deviceToDeregister else { return }
+        isDeregistering = true
+        error = nil
+        do {
+            try await manageNotificationsUseCase.unregisterDevice(token: device.deviceToken)
+            devices.removeAll { $0.id == device.id }
+            showDeregisterConfirmation = false
+            deviceToDeregister = nil
+            Logger.data.info("Device deregistered successfully")
+        } catch {
+            self.error = mapError(error, fallback: "Failed to deregister device")
+            Logger.data.error("Deregister device failed: \(error)")
+        }
+        isDeregistering = false
+    }
+
+    func dismissError() {
+        error = nil
+    }
+
+    private func mapError(_ error: any Error, fallback: String) -> String {
+        guard let apiError = error as? APIError else {
+            return fallback
+        }
+        switch apiError {
+        case .unauthorized, .tokenRefreshFailed:
+            return "Session expired. Please sign in again."
+        case .networkError:
+            return "Network error. Check your connection and try again."
+        case .serverError:
+            return "Server error. Please try again later."
+        case .rateLimited:
+            return "Too many requests. Please try again later."
+        case .notFound:
+            return "Device not found. It may have already been removed."
+        default:
+            return fallback
+        }
+    }
+}

--- a/AarogyaiOS/Presentation/Settings/SettingsView.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsView.swift
@@ -22,6 +22,10 @@ struct SettingsView: View {
                     Label("Notifications", systemImage: "bell")
                 }
                 .accessibilityIdentifier(AccessibilityID.Settings.notificationsRow)
+                NavigationLink(value: SettingsRoute.registeredDevices) {
+                    Label("Registered Devices", systemImage: "laptopcomputer.and.iphone")
+                }
+                .accessibilityIdentifier(AccessibilityID.Settings.registeredDevicesRow)
             }
 
             Section {
@@ -105,6 +109,11 @@ struct SettingsView: View {
             case .notifications:
                 NotificationPreferencesView(viewModel: NotificationPreferencesViewModel(
                     manageNotificationsUseCase: viewModel.manageNotificationsUseCase
+                ))
+            case .registeredDevices:
+                RegisteredDevicesView(viewModel: RegisteredDevicesViewModel(
+                    manageNotificationsUseCase: viewModel.manageNotificationsUseCase,
+                    deviceTokenManager: viewModel.deviceTokenManager
                 ))
             }
         }
@@ -256,4 +265,5 @@ enum SettingsRoute: Hashable {
     case aadhaarVerification
     case consents
     case notifications
+    case registeredDevices
 }

--- a/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
+++ b/AarogyaiOS/Presentation/Settings/SettingsViewModel.swift
@@ -25,6 +25,7 @@ final class SettingsViewModel {
     let verifyAadhaarUseCase: VerifyAadhaarUseCase
     let manageConsentsUseCase: ManageConsentsUseCase
     let manageNotificationsUseCase: ManageNotificationsUseCase
+    let deviceTokenManager: any DeviceTokenManaging
     private let logoutUseCase: LogoutUseCase
     private let exportDataUseCase: ExportDataUseCase
     private let requestAccountDeletionUseCase: RequestAccountDeletionUseCase
@@ -39,6 +40,7 @@ final class SettingsViewModel {
         verifyAadhaarUseCase: VerifyAadhaarUseCase,
         manageConsentsUseCase: ManageConsentsUseCase,
         manageNotificationsUseCase: ManageNotificationsUseCase,
+        deviceTokenManager: any DeviceTokenManaging,
         logoutUseCase: LogoutUseCase,
         exportDataUseCase: ExportDataUseCase,
         requestAccountDeletionUseCase: RequestAccountDeletionUseCase,
@@ -49,6 +51,7 @@ final class SettingsViewModel {
         self.verifyAadhaarUseCase = verifyAadhaarUseCase
         self.manageConsentsUseCase = manageConsentsUseCase
         self.manageNotificationsUseCase = manageNotificationsUseCase
+        self.deviceTokenManager = deviceTokenManager
         self.logoutUseCase = logoutUseCase
         self.exportDataUseCase = exportDataUseCase
         self.requestAccountDeletionUseCase = requestAccountDeletionUseCase

--- a/AarogyaiOS/Utilities/AccessibilityID.swift
+++ b/AarogyaiOS/Utilities/AccessibilityID.swift
@@ -85,6 +85,7 @@ enum AccessibilityID {
         static let deleteConfirmFinalButton = "settings.deleteAccount.confirm.final"
         static let deleteCancelButton = "settings.deleteAccount.cancel"
         static let signOutButton = "settings.signOut"
+        static let registeredDevicesRow = "settings.registeredDevices"
         static let versionLabel = "settings.version"
     }
 
@@ -111,6 +112,17 @@ enum AccessibilityID {
     // MARK: - Notification Preferences
     enum Notifications {
         static let saveButton = "notifications.save"
+    }
+
+    // MARK: - Registered Devices
+    enum RegisteredDevices {
+        static let list = "registeredDevices.list"
+        static let emptyState = "registeredDevices.emptyState"
+        static let loadingView = "registeredDevices.loading"
+        static func deviceRow(_ id: String) -> String { "registeredDevices.row.\(id)" }
+        static func currentBadge(_ id: String) -> String { "registeredDevices.current.\(id)" }
+        static func deregisterButton(_ id: String) -> String { "registeredDevices.deregister.\(id)" }
+        static let deregisterConfirmButton = "registeredDevices.deregister.confirm"
     }
 
     // MARK: - Aadhaar Verification

--- a/AarogyaiOSTests/Mocks/MockNotificationRepository.swift
+++ b/AarogyaiOSTests/Mocks/MockNotificationRepository.swift
@@ -8,11 +8,13 @@ final class MockNotificationRepository: NotificationRepository, @unchecked Senda
         DeviceToken(id: "dt-1", deviceToken: "token", platform: "ios", deviceName: "iPhone", appVersion: "1.0", registeredAt: .now, updatedAt: .now)
     )
     var unregisterDeviceResult: Result<Void, Error> = .success(())
+    var listDevicesResult: Result<[DeviceToken], Error> = .success([.stub])
 
     var getPreferencesCallCount = 0
     var updatePreferencesCallCount = 0
     var registerDeviceCallCount = 0
     var unregisterDeviceCallCount = 0
+    var listDevicesCallCount = 0
     var lastRegisteredToken: String?
     var lastUnregisteredToken: String?
     var lastUpdatedPreferences: NotificationPreferences?
@@ -38,5 +40,10 @@ final class MockNotificationRepository: NotificationRepository, @unchecked Senda
         unregisterDeviceCallCount += 1
         lastUnregisteredToken = token
         try unregisterDeviceResult.get()
+    }
+
+    func listDevices() async throws -> [DeviceToken] {
+        listDevicesCallCount += 1
+        return try listDevicesResult.get()
     }
 }

--- a/AarogyaiOSTests/Presentation/RegisteredDevicesViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/RegisteredDevicesViewModelTests.swift
@@ -1,0 +1,418 @@
+import Foundation
+import Testing
+@testable import AarogyaiOS
+
+@Suite("RegisteredDevicesViewModel")
+@MainActor
+struct RegisteredDevicesViewModelTests {
+    let notifRepo = MockNotificationRepository()
+    let deviceTokenManager = MockDeviceTokenManager()
+
+    func makeSUT() -> RegisteredDevicesViewModel {
+        RegisteredDevicesViewModel(
+            manageNotificationsUseCase: ManageNotificationsUseCase(
+                notificationRepository: notifRepo
+            ),
+            deviceTokenManager: deviceTokenManager
+        )
+    }
+
+    // MARK: - Initial State
+
+    @Test func initialStateIsEmpty() {
+        let sut = makeSUT()
+        #expect(sut.devices.isEmpty)
+        #expect(!sut.isLoading)
+        #expect(sut.error == nil)
+        #expect(sut.deviceToDeregister == nil)
+        #expect(!sut.showDeregisterConfirmation)
+        #expect(!sut.isDeregistering)
+    }
+
+    // MARK: - Current Device Token
+
+    @Test func currentDeviceTokenReturnsNilWhenNoToken() {
+        let sut = makeSUT()
+        #expect(sut.currentDeviceToken == nil)
+    }
+
+    @Test func currentDeviceTokenReturnsStoredToken() {
+        deviceTokenManager.storedToken = "current-token"
+        let sut = makeSUT()
+        #expect(sut.currentDeviceToken == "current-token")
+    }
+
+    // MARK: - Is Current Device
+
+    @Test func isCurrentDeviceReturnsTrueForMatchingToken() {
+        deviceTokenManager.storedToken = "token-1"
+        let sut = makeSUT()
+        let device = DeviceToken(
+            id: "dt-1", deviceToken: "token-1", platform: "ios",
+            deviceName: "iPhone", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        #expect(sut.isCurrentDevice(device))
+    }
+
+    @Test func isCurrentDeviceReturnsFalseForDifferentToken() {
+        deviceTokenManager.storedToken = "token-1"
+        let sut = makeSUT()
+        let device = DeviceToken(
+            id: "dt-2", deviceToken: "token-2", platform: "ios",
+            deviceName: "iPad", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        #expect(!sut.isCurrentDevice(device))
+    }
+
+    @Test func isCurrentDeviceReturnsFalseWhenNoStoredToken() {
+        let sut = makeSUT()
+        let device = DeviceToken(
+            id: "dt-1", deviceToken: "token-1", platform: "ios",
+            deviceName: "iPhone", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        #expect(!sut.isCurrentDevice(device))
+    }
+
+    // MARK: - Load Devices
+
+    @Test func loadDevicesPopulatesFromRepository() async {
+        let devices = [
+            DeviceToken(
+                id: "dt-1", deviceToken: "token-1", platform: "ios",
+                deviceName: "iPhone", appVersion: "1.0",
+                registeredAt: .now, updatedAt: .now
+            ),
+            DeviceToken(
+                id: "dt-2", deviceToken: "token-2", platform: "android",
+                deviceName: "Pixel", appVersion: "2.0",
+                registeredAt: .now, updatedAt: .now
+            ),
+        ]
+        notifRepo.listDevicesResult = .success(devices)
+        let sut = makeSUT()
+        await sut.loadDevices()
+
+        #expect(sut.devices.count == 2)
+        #expect(sut.devices[0].id == "dt-1")
+        #expect(sut.devices[1].id == "dt-2")
+        #expect(!sut.isLoading)
+        #expect(sut.error == nil)
+    }
+
+    @Test func loadDevicesCallsRepository() async {
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(notifRepo.listDevicesCallCount == 1)
+    }
+
+    @Test func loadDevicesSetsIsLoadingFalseAfterCompletion() async {
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(!sut.isLoading)
+    }
+
+    @Test func loadDevicesClearsErrorOnNewAttempt() async {
+        notifRepo.listDevicesResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error != nil)
+
+        notifRepo.listDevicesResult = .success([.stub])
+        await sut.loadDevices()
+        #expect(sut.error == nil)
+    }
+
+    @Test func loadDevicesHandlesEmptyList() async {
+        notifRepo.listDevicesResult = .success([])
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.devices.isEmpty)
+        #expect(sut.error == nil)
+    }
+
+    // MARK: - Load Devices Error Handling
+
+    @Test func loadDevicesHandlesServerError() async {
+        notifRepo.listDevicesResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Server error. Please try again later.")
+    }
+
+    @Test func loadDevicesHandlesNetworkError() async {
+        notifRepo.listDevicesResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Network error. Check your connection and try again.")
+    }
+
+    @Test func loadDevicesHandlesUnauthorizedError() async {
+        notifRepo.listDevicesResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func loadDevicesHandlesTokenRefreshFailed() async {
+        notifRepo.listDevicesResult = .failure(APIError.tokenRefreshFailed)
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func loadDevicesHandlesRateLimited() async {
+        notifRepo.listDevicesResult = .failure(APIError.rateLimited(retryAfter: 60))
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Too many requests. Please try again later.")
+    }
+
+    @Test func loadDevicesHandlesUnknownAPIError() async {
+        notifRepo.listDevicesResult = .failure(APIError.unknown(status: 418))
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Failed to load registered devices")
+    }
+
+    @Test func loadDevicesHandlesNonAPIError() async {
+        struct CustomError: Error {}
+        notifRepo.listDevicesResult = .failure(CustomError())
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error == "Failed to load registered devices")
+        #expect(!sut.isLoading)
+    }
+
+    // MARK: - Confirm Deregister
+
+    @Test func confirmDeregisterSetsDeviceAndShowsConfirmation() {
+        let sut = makeSUT()
+        let device = DeviceToken.stub
+        sut.confirmDeregister(device)
+        #expect(sut.deviceToDeregister?.id == device.id)
+        #expect(sut.showDeregisterConfirmation)
+    }
+
+    // MARK: - Cancel Deregister
+
+    @Test func cancelDeregisterClearsState() {
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        sut.showDeregisterConfirmation = true
+        sut.cancelDeregister()
+        #expect(sut.deviceToDeregister == nil)
+        #expect(!sut.showDeregisterConfirmation)
+    }
+
+    // MARK: - Deregister Device
+
+    @Test func deregisterDeviceCallsRepository() async {
+        let device = DeviceToken.stub
+        let sut = makeSUT()
+        sut.deviceToDeregister = device
+        await sut.deregisterDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 1)
+        #expect(notifRepo.lastUnregisteredToken == device.deviceToken)
+    }
+
+    @Test func deregisterDeviceRemovesFromList() async {
+        let device = DeviceToken.stub
+        let sut = makeSUT()
+        sut.devices = [device]
+        sut.deviceToDeregister = device
+        await sut.deregisterDevice()
+        #expect(sut.devices.isEmpty)
+    }
+
+    @Test func deregisterDeviceClearsConfirmationState() async {
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        sut.showDeregisterConfirmation = true
+        await sut.deregisterDevice()
+        #expect(!sut.showDeregisterConfirmation)
+        #expect(sut.deviceToDeregister == nil)
+    }
+
+    @Test func deregisterDeviceSetsIsDeregisteringFalseAfterSuccess() async {
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(!sut.isDeregistering)
+    }
+
+    @Test func deregisterDeviceDoesNothingWhenNoDevice() async {
+        let sut = makeSUT()
+        sut.deviceToDeregister = nil
+        await sut.deregisterDevice()
+        #expect(notifRepo.unregisterDeviceCallCount == 0)
+    }
+
+    @Test func deregisterDeviceOnlyRemovesTargetDevice() async {
+        let device1 = DeviceToken(
+            id: "dt-1", deviceToken: "token-1", platform: "ios",
+            deviceName: "iPhone", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        let device2 = DeviceToken(
+            id: "dt-2", deviceToken: "token-2", platform: "ios",
+            deviceName: "iPad", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        let sut = makeSUT()
+        sut.devices = [device1, device2]
+        sut.deviceToDeregister = device1
+        await sut.deregisterDevice()
+        #expect(sut.devices.count == 1)
+        #expect(sut.devices[0].id == "dt-2")
+    }
+
+    @Test func deregisterDeviceClearsErrorOnNewAttempt() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error != nil)
+
+        notifRepo.unregisterDeviceResult = .success(())
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == nil)
+    }
+
+    // MARK: - Deregister Device Error Handling
+
+    @Test func deregisterDeviceHandlesServerError() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Server error. Please try again later.")
+    }
+
+    @Test func deregisterDeviceHandlesNetworkError() async {
+        notifRepo.unregisterDeviceResult = .failure(
+            APIError.networkError(underlying: URLError(.notConnectedToInternet))
+        )
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Network error. Check your connection and try again.")
+    }
+
+    @Test func deregisterDeviceHandlesUnauthorizedError() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.unauthorized)
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func deregisterDeviceHandlesTokenRefreshFailed() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.tokenRefreshFailed)
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Session expired. Please sign in again.")
+    }
+
+    @Test func deregisterDeviceHandlesRateLimited() async {
+        notifRepo.unregisterDeviceResult = .failure(
+            APIError.rateLimited(retryAfter: 30)
+        )
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Too many requests. Please try again later.")
+    }
+
+    @Test func deregisterDeviceHandlesNotFoundError() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.notFound)
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Device not found. It may have already been removed.")
+    }
+
+    @Test func deregisterDeviceHandlesUnknownAPIError() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.unknown(status: 418))
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Failed to deregister device")
+    }
+
+    @Test func deregisterDeviceHandlesNonAPIError() async {
+        struct CustomError: Error {}
+        notifRepo.unregisterDeviceResult = .failure(CustomError())
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.error == "Failed to deregister device")
+        #expect(!sut.isDeregistering)
+    }
+
+    @Test func deregisterDeviceSetsIsDeregisteringFalseAfterFailure() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(!sut.isDeregistering)
+    }
+
+    @Test func deregisterDeviceDoesNotRemoveFromListOnFailure() async {
+        notifRepo.unregisterDeviceResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        sut.devices = [.stub]
+        sut.deviceToDeregister = .stub
+        await sut.deregisterDevice()
+        #expect(sut.devices.count == 1)
+    }
+
+    // MARK: - Dismiss Error
+
+    @Test func dismissErrorClearsError() async {
+        notifRepo.listDevicesResult = .failure(APIError.serverError(status: 500))
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.error != nil)
+        sut.dismissError()
+        #expect(sut.error == nil)
+    }
+
+    // MARK: - Multiple Operations
+
+    @Test func multipleLoadDevicesCallsTrackCount() async {
+        let sut = makeSUT()
+        await sut.loadDevices()
+        await sut.loadDevices()
+        #expect(notifRepo.listDevicesCallCount == 2)
+    }
+
+    @Test func loadAfterDeregisterShowsUpdatedList() async {
+        let device1 = DeviceToken(
+            id: "dt-1", deviceToken: "token-1", platform: "ios",
+            deviceName: "iPhone", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        let device2 = DeviceToken(
+            id: "dt-2", deviceToken: "token-2", platform: "ios",
+            deviceName: "iPad", appVersion: "1.0",
+            registeredAt: .now, updatedAt: .now
+        )
+        notifRepo.listDevicesResult = .success([device1, device2])
+        let sut = makeSUT()
+        await sut.loadDevices()
+        #expect(sut.devices.count == 2)
+
+        // Deregister first device
+        sut.deviceToDeregister = device1
+        await sut.deregisterDevice()
+        #expect(sut.devices.count == 1)
+        #expect(sut.devices[0].id == "dt-2")
+    }
+}

--- a/AarogyaiOSTests/Presentation/SettingsViewModelTests.swift
+++ b/AarogyaiOSTests/Presentation/SettingsViewModelTests.swift
@@ -19,6 +19,7 @@ struct SettingsViewModelTests {
             verifyAadhaarUseCase: VerifyAadhaarUseCase(userRepository: userRepo),
             manageConsentsUseCase: ManageConsentsUseCase(consentRepository: consentRepo),
             manageNotificationsUseCase: ManageNotificationsUseCase(notificationRepository: notifRepo),
+            deviceTokenManager: MockDeviceTokenManager(),
             logoutUseCase: LogoutUseCase(authRepository: authRepo, tokenStore: tokenStore),
             exportDataUseCase: ExportDataUseCase(userRepository: userRepo),
             requestAccountDeletionUseCase: RequestAccountDeletionUseCase(userRepository: userRepo),


### PR DESCRIPTION
## Summary
- Add devicesList endpoint to APIEndpoint
- Add listDevices() to NotificationRepository protocol and implementation
- Create RegisteredDevicesViewModel with load, deregister, current device detection
- Create RegisteredDevicesView with device list, swipe-to-deregister, current device badge
- Wire into Settings via new registeredDevices navigation route
- Add 40 comprehensive unit tests

Closes #107

## Test plan
- Navigate to Settings > Registered Devices
- Verify device list loads with name, platform, version, and date
- Verify current device highlighted with This Device badge
- Swipe left on a device and confirm deregistration
- Verify empty state when no devices registered
- Run unit tests: all 40 RegisteredDevicesViewModelTests pass