### PR TITLE
fix(reports): simplify upload to only require report type

### DIFF
--- a/AarogyaiOS/Data/Network/DTOs/Reports/ReportDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Reports/ReportDTO.swift
@@ -60,13 +60,23 @@ struct ExtractionDTO: Decodable, Sendable {
 }
 
 struct CreateReportRequestDTO: Encodable, Sendable {
-    let fileStorageKey: String
+    let objectKey: String
     let reportType: String
-    let title: String?
-    let reportDate: String?
-    let doctorName: String?
     let labName: String?
+    let parameters: [ReportParameterRequestDTO]
     let notes: String?
+    let collectedAt: String?
+    let reportedAt: String?
+}
+
+struct ReportParameterRequestDTO: Encodable, Sendable {
+    let code: String
+    let name: String
+    let numericValue: Double?
+    let textValue: String?
+    let unit: String?
+    let referenceRange: String?
+    let isAbnormal: Bool?
 }
 
 struct UploadUrlRequestDTO: Encodable, Sendable {

--- a/AarogyaiOS/Data/Repositories/DefaultReportRepository.swift
+++ b/AarogyaiOS/Data/Repositories/DefaultReportRepository.swift
@@ -74,13 +74,13 @@ struct DefaultReportRepository: ReportRepository {
 
     func createReport(request: CreateReportInput) async throws -> Report {
         let dto = CreateReportRequestDTO(
-            fileStorageKey: request.fileStorageKey,
+            objectKey: request.objectKey,
             reportType: request.reportType.rawValue,
-            title: request.title,
-            reportDate: request.reportDate?.iso8601String,
-            doctorName: request.doctorName,
-            labName: request.labName,
-            notes: request.notes
+            labName: nil,
+            parameters: [],
+            notes: nil,
+            collectedAt: nil,
+            reportedAt: nil
         )
         let response: ReportDetailDTO = try await apiClient.request(.createReport, body: dto)
         let report = ReportMapper.toDomain(response)

--- a/AarogyaiOS/Domain/Repositories/ReportRepository.swift
+++ b/AarogyaiOS/Domain/Repositories/ReportRepository.swift
@@ -52,13 +52,8 @@ struct PaginatedResult<T: Sendable>: Sendable {
 }
 
 struct CreateReportInput: Sendable {
-    let fileStorageKey: String
+    let objectKey: String
     let reportType: ReportType
-    let title: String?
-    let reportDate: Date?
-    let doctorName: String?
-    let labName: String?
-    let notes: String?
 }
 
 struct PresignedUpload: Sendable {

--- a/AarogyaiOS/Domain/UseCases/Reports/UploadReportUseCase.swift
+++ b/AarogyaiOS/Domain/UseCases/Reports/UploadReportUseCase.swift
@@ -27,13 +27,8 @@ struct UploadReportUseCase: Sendable {
 
         return try await reportRepository.createReport(
             request: CreateReportInput(
-                fileStorageKey: presigned.fileStorageKey,
-                reportType: input.reportType,
-                title: input.title,
-                reportDate: input.reportDate,
-                doctorName: input.doctorName,
-                labName: input.labName,
-                notes: input.notes
+                objectKey: presigned.fileStorageKey,
+                reportType: input.reportType
             )
         )
     }
@@ -44,11 +39,6 @@ struct UploadReportInput: Sendable {
     let fileName: String
     let contentType: String
     let reportType: ReportType
-    let title: String?
-    let reportDate: Date?
-    let doctorName: String?
-    let labName: String?
-    let notes: String?
 }
 
 protocol FileUploading: Sendable {

--- a/AarogyaiOS/Presentation/Reports/ReportUploadView.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportUploadView.swift
@@ -21,8 +21,6 @@ struct ReportUploadView: View {
                         switch viewModel.currentStep {
                         case .fileSelection:
                             fileSelectionStep
-                        case .metadata:
-                            metadataStep
                         case .uploading:
                             uploadingStep
                         }
@@ -61,13 +59,13 @@ struct ReportUploadView: View {
         .padding(.vertical, 8)
     }
 
-    // MARK: - Step 1: File Selection
+    // MARK: - Step 1: File Selection + Report Type
 
     @State private var showFilePicker = false
 
     private var fileSelectionStep: some View {
         VStack(spacing: 20) {
-            Text("Select a file")
+            Text("Upload Report")
                 .font(Typography.title)
 
             Button {
@@ -116,6 +114,23 @@ struct ReportUploadView: View {
                     .font(Typography.caption)
                     .foregroundStyle(Color.Fallback.statusCritical)
             }
+
+            if viewModel.fileData != nil {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Report Type")
+                        .font(Typography.callout)
+                        .foregroundStyle(.secondary)
+
+                    Picker("Report Type", selection: $viewModel.reportType) {
+                        ForEach(ReportType.allCases, id: \.self) { type in
+                            Text(type.displayName)
+                                .tag(type)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
         }
     }
 
@@ -133,48 +148,7 @@ struct ReportUploadView: View {
         }
     }
 
-    // MARK: - Step 2: Metadata
-
-    private var metadataStep: some View {
-        VStack(spacing: 16) {
-            Text("Report Details")
-                .font(Typography.title)
-
-            TextField("Title (optional)", text: $viewModel.title)
-                .font(Typography.body)
-                .padding(12)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-
-            Picker("Report Type", selection: $viewModel.reportType) {
-                ForEach(ReportType.allCases, id: \.self) { type in
-                    Text(type.displayName)
-                        .tag(type)
-                }
-            }
-            .pickerStyle(.menu)
-
-            DatePicker("Report Date", selection: $viewModel.reportDate, displayedComponents: .date)
-                .font(Typography.body)
-
-            TextField("Doctor Name (optional)", text: $viewModel.doctorName)
-                .font(Typography.body)
-                .padding(12)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-
-            TextField("Lab Name (optional)", text: $viewModel.labName)
-                .font(Typography.body)
-                .padding(12)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-
-            TextField("Notes (optional)", text: $viewModel.notes, axis: .vertical)
-                .font(Typography.body)
-                .lineLimit(3...6)
-                .padding(12)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-        }
-    }
-
-    // MARK: - Step 3: Upload Progress
+    // MARK: - Step 2: Upload Progress
 
     private var uploadingStep: some View {
         VStack(spacing: 24) {
@@ -257,21 +231,11 @@ struct ReportUploadView: View {
 
     private var navigationButtons: some View {
         HStack(spacing: 12) {
-            if viewModel.currentStep != .fileSelection {
-                SecondaryButton("Back", icon: "chevron.left") {
-                    viewModel.previousStep()
-                }
-            }
-
             if viewModel.currentStep == .fileSelection {
-                PrimaryButton("Continue", icon: "chevron.right") {
-                    viewModel.nextStep()
-                }
-                .disabled(!viewModel.canProceedFromStep1 || viewModel.isFileTooLarge)
-            } else if viewModel.currentStep == .metadata {
                 PrimaryButton("Upload", icon: "arrow.up") {
                     viewModel.nextStep()
                 }
+                .disabled(!viewModel.canProceedFromStep1 || viewModel.isFileTooLarge)
             }
         }
         .padding(24)

--- a/AarogyaiOS/Presentation/Reports/ReportUploadViewModel.swift
+++ b/AarogyaiOS/Presentation/Reports/ReportUploadViewModel.swift
@@ -6,8 +6,7 @@ import OSLog
 final class ReportUploadViewModel {
     enum UploadStep: Int, CaseIterable {
         case fileSelection = 1
-        case metadata = 2
-        case uploading = 3
+        case uploading = 2
     }
 
     enum UploadState {
@@ -20,20 +19,13 @@ final class ReportUploadViewModel {
     // Navigation
     var currentStep: UploadStep = .fileSelection
 
-    // Step 1: File
+    // Step 1: File Selection + Report Type
     var fileData: Data?
     var fileName: String = ""
     var fileContentType: String = "application/pdf"
-
-    // Step 2: Metadata
-    var title: String = ""
     var reportType: ReportType = .bloodTest
-    var reportDate: Date = .now
-    var doctorName: String = ""
-    var labName: String = ""
-    var notes: String = ""
 
-    // Step 3: Upload
+    // Step 2: Upload
     var uploadState: UploadState = .idle
 
     private let uploadReportUseCase: UploadReportUseCase
@@ -60,16 +52,11 @@ final class ReportUploadViewModel {
         fileData = data
         fileName = name
         fileContentType = contentType
-        title = name.replacingOccurrences(of: ".pdf", with: "")
-            .replacingOccurrences(of: ".jpg", with: "")
-            .replacingOccurrences(of: ".png", with: "")
     }
 
     func nextStep() {
         switch currentStep {
         case .fileSelection:
-            currentStep = .metadata
-        case .metadata:
             currentStep = .uploading
             Task { await startUpload() }
         case .uploading:
@@ -81,8 +68,6 @@ final class ReportUploadViewModel {
         switch currentStep {
         case .fileSelection:
             break
-        case .metadata:
-            currentStep = .fileSelection
         case .uploading:
             break
         }
@@ -98,12 +83,7 @@ final class ReportUploadViewModel {
                 fileData: fileData,
                 fileName: fileName,
                 contentType: fileContentType,
-                reportType: reportType,
-                title: title.isEmpty ? nil : title,
-                reportDate: reportDate,
-                doctorName: doctorName.isEmpty ? nil : doctorName,
-                labName: labName.isEmpty ? nil : labName,
-                notes: notes.isEmpty ? nil : notes
+                reportType: reportType
             )
 
             let report = try await uploadReportUseCase.execute(input: input) { [weak self] progress in


### PR DESCRIPTION
## Summary

Simplified the iOS report upload flow to match the new backend contract. The backend now only requires `reportType` and `objectKey` when creating reports — all other metadata (lab name, dates, notes, parameters) is optional and extracted by downstream processes.

### Changes

- **DTOs**: Updated `CreateReportRequestDTO` to use `objectKey` instead of `fileStorageKey`, added `parameters` array field, removed `title`, `reportDate`, and `doctorName` fields
- **Upload Flow**: Removed the metadata step — users now only select a file and choose a report type
- **UI Simplification**: 
  - Collapsed 3-step wizard to 2 steps (file selection + type picker → upload)
  - Removed input fields for title, report date, doctor name, lab name, and notes
  - Report type picker now appears inline after file selection
- **Domain Layer**: Simplified `UploadReportInput` and `CreateReportInput` to only include required fields
- **Repository**: `DefaultReportRepository.createReport()` sends minimal payload with empty `parameters` array

### Backend Contract

The backend `POST /api/v1/reports` now accepts:
```json
{
  "reportType": "blood_test",   // required
  "objectKey": "reports/...",   // required  
  "labName": null,              // optional
  "parameters": [],             // can be empty
  "notes": null,                // optional
  "collectedAt": null,          // optional
  "reportedAt": null            // optional
}
```

### Test Plan

- [x] Build succeeds on iOS 26 simulator (iPhone 17 Pro)
- [ ] Manual test: Upload a PDF report and verify it creates successfully
- [ ] Manual test: Upload a JPEG/PNG image and verify it creates successfully
- [ ] Manual test: Verify report type picker shows all options
- [ ] Verify uploaded report appears in reports list with correct type
- [ ] Verify extraction process can run on uploaded report

Generated with [Claude Code](https://claude.com/claude-code)