### PR TITLE
fix(reports): align DTOs with backend id field rename

### DIFF
--- a/AarogyaiOS/Data/Network/DTOs/Reports/ReportDTO.swift
+++ b/AarogyaiOS/Data/Network/DTOs/Reports/ReportDTO.swift
@@ -1,19 +1,17 @@
 import Foundation
 
 struct ReportSummaryDTO: Decodable, Sendable {
-    let reportId: String
-    let reportNumber: String
+    let id: String
     let title: String
     let reportType: String
     let status: String
-    let patientId: String
-    let uploadedAt: String
+    let createdAt: String
     let labName: String?
     let highlightParameter: String?
 }
 
 struct ReportDetailDTO: Decodable, Sendable {
-    let reportId: String
+    let id: String
     let reportNumber: String
     let title: String
     let reportType: String

--- a/AarogyaiOS/Data/Network/Mappers/ReportMapper.swift
+++ b/AarogyaiOS/Data/Network/Mappers/ReportMapper.swift
@@ -3,7 +3,7 @@ import Foundation
 enum ReportMapper {
     static func toDomain(_ dto: ReportDetailDTO) -> Report {
         Report(
-            id: dto.reportId,
+            id: dto.id,
             reportNumber: dto.reportNumber,
             title: dto.title,
             reportType: ReportType(rawValue: dto.reportType) ?? .other,
@@ -30,18 +30,18 @@ enum ReportMapper {
 
     static func toDomain(_ dto: ReportSummaryDTO) -> Report {
         Report(
-            id: dto.reportId,
-            reportNumber: dto.reportNumber,
+            id: dto.id,
+            reportNumber: "",
             title: dto.title,
             reportType: ReportType(rawValue: dto.reportType) ?? .other,
             status: ReportStatus(rawValue: dto.status) ?? .draft,
-            patientId: dto.patientId,
+            patientId: "",
             doctorId: nil,
             doctorName: nil,
             labName: dto.labName,
             collectedAt: nil,
             reportedAt: nil,
-            uploadedAt: Date(iso8601: dto.uploadedAt) ?? .now,
+            uploadedAt: Date(iso8601: dto.createdAt) ?? .now,
             notes: nil,
             fileStorageKey: nil,
             fileType: nil,
@@ -50,8 +50,8 @@ enum ReportMapper {
             parameters: [],
             extraction: nil,
             highlightParameter: dto.highlightParameter,
-            createdAt: .now,
-            updatedAt: .now
+            createdAt: Date(iso8601: dto.createdAt) ?? .now,
+            updatedAt: Date(iso8601: dto.createdAt) ?? .now
         )
     }
 


### PR DESCRIPTION
## Summary

- Updates `ReportSummaryDTO` and `ReportDetailDTO` to use `id` instead of `reportId`, matching the backend's renamed field
- Adjusts `ReportSummaryDTO` fields to match the enriched backend response (`createdAt`, `labName`, `highlightParameter`)
- Updates `ReportMapper` to use the new DTO field names

**Depends on**: Backend kinveetech/AarogyaBackend#TBD (deploy first)

## Test plan

- [ ] iOS CI build passes
- [ ] Report list and detail views work with new response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)